### PR TITLE
Remove redundant params input from unit test cases

### DIFF
--- a/test/unit/modules/test_sensu_go_asset.py
+++ b/test/unit/modules/test_sensu_go_asset.py
@@ -69,7 +69,6 @@ class TestSensuAssetModule(ModuleTestCase, TestSensuGoObjectBase):
         dict(
             name='Update existing asset',
             params={
-                'url': 'http://qweqweqweqwe:8081',
                 'name': 'test_asset',
                 'download_url': 'http://example.com/new-asset.tar.gz',
                 'sha512': 'new-sha512String',

--- a/test/unit/modules/test_sensu_go_filter.py
+++ b/test/unit/modules/test_sensu_go_filter.py
@@ -108,10 +108,7 @@ class TestSensuFilterModule(ModuleTestCase, TestSensuGoObjectBase):
             name='Delete Filter',
             params={
                 'name': 'test_filter',
-                'state': 'absent',
-                'action': 'allow',
-                'expressions': ['event.check.occurrences == 1'],
-                'runtime_assets': []
+                'state': 'absent'
             },
             expect_changed=False
         ),
@@ -193,10 +190,7 @@ class TestSensuFilterModule(ModuleTestCase, TestSensuGoObjectBase):
             name='(check) Delete Filter',
             params={
                 'name': 'test_filter',
-                'state': 'absent',
-                'action': 'allow',
-                'expressions': ['event.check.occurrences == 1'],
-                'runtime_assets': ['ruby-2.4.4']
+                'state': 'absent'
             },
             check_mode=True,
             expect_changed=False,


### PR DESCRIPTION
Removed some params when testing delete operation on objects.