### PR TITLE
Clean up the CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,64 +1,103 @@
-version: 2
+version: "2.1"
+
+executors:
+  python27:
+    docker: [ { image: circleci/python:2.7 } ]
+    environment: { PY: "2.7" }
+  python37:
+    docker: [ { image: circleci/python:3.7 } ]
+    environment: { PY: "3.7" }
+
+commands:
+  common_setup:
+    description: Common steps for all jobs
+    steps:
+      - checkout
+      - run:
+          name: Create virtual environment
+          command: virtualenv ${HOME}/venv
+      - run:
+          name: Checkout the devel Ansible branch
+          command: |
+            git clone -b devel --depth 1 \
+              https://github.com/ansible/ansible.git ${HOME}/ansible
+      - run:
+          name: Set environment variables
+          command: |
+            echo 'PATH=${HOME}/ansible/bin:${HOME}/venv/bin:$PATH' >> $BASH_ENV
+            echo 'PYTHONPATH=${HOME}/ansible/lib' >> $BASH_ENV
+            echo 'MANPATH=/tmp/man' >> $BASH_ENV
+            echo 'export PATH PYTHONPATH MANPATH' >> $BASH_ENV
+      - run:
+          name: Install Ansible and core dependencies
+          command: pip install -r ${HOME}/ansible/requirements.txt
+      - run:
+          name: Build sensu_go collection
+          command: ansible-galaxy collection build
+      - run:
+          name: Install sensu_go collection
+          command: |
+            ansible-galaxy collection install \
+              -p ${HOME}/.ansible/collections \
+              sensu-sensu_go-*.tar.gz
+
+  run_test:
+    description: Run selected test
+    parameters:
+      kind:
+        description: Kind of tests to run
+        type: enum
+        enum: [ sanity, units, integration ]
+      args:
+        description: Arguments for this invocation
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: Run test
+          command: |
+            cd ${HOME}/.ansible/collections/ansible_collections/sensu/sensu_go
+            ansible-test << parameters.kind >> \
+              --python ${PY} \
+              --requirements \
+              << parameters.args >>
 
 jobs:
   sanity:
-    docker: [{image: circleci/python:3.7}]
-    environment: {MANPATH: /tmp/man}
+    executor: python37
     steps:
-      - checkout
-      - run: &checkout_ansible
-          name: Checkout Ansible 2.9 from GitHub
-          command: |
-            git clone -b devel  https://github.com/ansible/ansible.git ~/ansible
-      - run: &install_collection
-          name: Install collection so Ansible can see it
-          command: |
-            mkdir -p ~/.ansible/collections/ansible_collections/sensu
+      - common_setup
+      - run_test:
+          kind: sanity
+          args: --test pep8
 
-            # We can't use mazer to install it because it would create symlink and
-            # ansible-test command can not work with symlinks.
-            cp -r ~/project ~/.ansible/collections/ansible_collections/sensu/sensu_go/
-      - run:
-          name: Sanity Check
-          command: |
-            . ~/ansible/hacking/env-setup
-            cd ~/.ansible/collections/ansible_collections/sensu/sensu_go
-            sudo ~/ansible/bin/ansible-test sanity --test pep8 --python 3.7 --requirements
-
-  unit_test: &unit_test
-    docker: [{image: circleci/python:3.7}]
+  unit_test_python27:
+    executor: python27
     steps:
-      - checkout
-      - run: { <<: *checkout_ansible }
-      - run: { <<: *install_collection }
-      - run:
-          name: Unit test
-          command: |
-            export MANPATH=/tmp/man
-            export PATH=$PATH:~/.local/bin
-            . ~/ansible/hacking/env-setup
-            cd ~/.ansible/collections/ansible_collections/sensu/sensu_go
-            sudo ~/ansible/bin/ansible-test units --python ${PY} --requirements --verbose
+      - common_setup
+      - run_test:
+          kind: units
+          args: --verbose
 
-  unit_py3: {<<: *unit_test, docker: [{image: circleci/python:3.7}],  environment: {PY: 3.7}}
-  unit_py2: {<<: *unit_test, docker: [{image: circleci/python:2.7}],  environment: {PY: 2.7}}
+  unit_test_python37:
+    executor: python37
+    steps:
+      - common_setup
+      - run_test:
+          kind: units
+          args: --verbose
 
   integration_modules:
-    docker: [{image: circleci/python:3.7}]
-    environment: {MANPATH: /tmp/man}
+    executor: python37
     steps:
-      - checkout
-      - run: { <<: *checkout_ansible }
-      - run: { <<: *install_collection }
+      - common_setup
       - setup_remote_docker
       - run:
           name: Install molecule
-          command: pip install -r ./requirements-dev.txt --user
+          command: pip install -r ./requirements-dev.txt
       - run:
           name: Integration Tests (modules)
           command: |
-            export PATH=$PATH:~/.local/bin
-            . ~/ansible/hacking/env-setup
             cd test/integration/modules
             molecule --base-config molecule/shared/base.yml test --all
 
@@ -67,6 +106,6 @@ workflows:
   main_workflow:
     jobs:
       - sanity
-      - unit_py3
-#      - unit_py2
+      # - unit_test_python27
+      - unit_test_python37
       - integration_modules


### PR DESCRIPTION
Since CircleCI natively supports reusable parameterized commands, there is no need to mess around with various YAML copy-paste and merge constructs (which are only supported in YAML 1.1, YAML 1.2 got rid of the merge operator).

We also made sure that tests are run against the installed collection. This simulates how the collection will behave when end-users will use it.

We also got rid of the sudo calls. We now run Ansible from a dedicated virtual environment that regular users can modify.

Note that we did not change the tests that are running. We still skip the 2.7 tests and sanity is still restricted to pep8 tests. We will fix this in a separate contribution.