### PR TITLE
Make test code python 2 and 3 compatible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,6 @@ workflows:
   main_workflow:
     jobs:
       - sanity
-      # - unit_test_python27
+      - unit_test_python27
       - unit_test_python37
       - integration_modules

--- a/test/unit/modules/common/sensu_go_object.py
+++ b/test/unit/modules/common/sensu_go_object.py
@@ -1,13 +1,17 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 import re
 import json
 import copy
 
-from unittest.mock import patch
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.utils import ModuleTestCase, \
-    set_module_args, AnsibleFailJson, AnsibleExitJson
+import pytest
+
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 
-import pytest
+from .utils import (
+    ModuleTestCase, set_module_args, AnsibleFailJson, AnsibleExitJson, patch
+)
 
 
 class TestSensuGoObjectBase(object):

--- a/test/unit/modules/common/sensu_go_object_info.py
+++ b/test/unit/modules/common/sensu_go_object_info.py
@@ -1,13 +1,13 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 import re
 import json
 import copy
 
-from unittest.mock import patch
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.utils import ModuleTestCase, \
-    set_module_args, AnsibleExitJson
-
-
 import pytest
+
+from .utils import ModuleTestCase, set_module_args, AnsibleExitJson, patch
 
 
 class TestSensuGoObjectInfoBase(object):

--- a/test/unit/modules/common/utils.py
+++ b/test/unit/modules/common/utils.py
@@ -1,8 +1,15 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 import json
 
-from unittest.mock import patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
+
+try:
+    from unittest.mock import patch  # Python 3
+except ImportError:
+    from mock import patch  # Python 2 needs mock package installed
 
 
 def set_module_args(args):

--- a/test/unit/modules/test_sensu_go_asset.py
+++ b/test/unit/modules/test_sensu_go_asset.py
@@ -1,8 +1,12 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 import pytest
 
 from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_asset
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.utils import ModuleTestCase, generate_name
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.sensu_go_object import TestSensuGoObjectBase
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object import TestSensuGoObjectBase
 
 
 class TestSensuAssetModule(ModuleTestCase, TestSensuGoObjectBase):

--- a/test/unit/modules/test_sensu_go_asset_info.py
+++ b/test/unit/modules/test_sensu_go_asset_info.py
@@ -1,8 +1,12 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 import pytest
 
 from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_asset_info
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.utils import ModuleTestCase, generate_name
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
 
 
 class TestSensuAssetModule(ModuleTestCase, TestSensuGoObjectInfoBase):

--- a/test/unit/modules/test_sensu_go_check.py
+++ b/test/unit/modules/test_sensu_go_check.py
@@ -1,8 +1,12 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 import pytest
 
 from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_check
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.utils import ModuleTestCase, generate_name
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.sensu_go_object import TestSensuGoObjectBase
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object import TestSensuGoObjectBase
 
 
 class TestSensuCheckModule(ModuleTestCase, TestSensuGoObjectBase):

--- a/test/unit/modules/test_sensu_go_filter.py
+++ b/test/unit/modules/test_sensu_go_filter.py
@@ -1,8 +1,12 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 import pytest
 
 from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_filter
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.utils import ModuleTestCase, generate_name
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.sensu_go_object import TestSensuGoObjectBase
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object import TestSensuGoObjectBase
 
 
 class TestSensuFilterModule(ModuleTestCase, TestSensuGoObjectBase):

--- a/test/unit/modules/test_sensu_go_mutator.py
+++ b/test/unit/modules/test_sensu_go_mutator.py
@@ -1,8 +1,12 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 import pytest
 
 from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_mutator
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.utils import ModuleTestCase, generate_name
-from ansible_collections.sensu.sensu_go.test.unit.modules.common.sensu_go_object import TestSensuGoObjectBase
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object import TestSensuGoObjectBase
 
 
 class TestSensuMutatorModule(ModuleTestCase, TestSensuGoObjectBase):


### PR DESCRIPTION
There were two main issues with the code that needed fixing in order to make it python 2 compatible:

 1. unittest.mock in not part of the standard library on python 2 and
 2. python 2 uses relative imports if not instructed otherwise.

We solved the first issue by placing the mock imports into the utils module and making sure that we handle python 2 as well.

Second issue was solved by adding absolute_import to the top of the source files, making imports behave like in python 3. And while we were at it, we also added other future imports that Ansible linter enforces and set the metaclass accordingly.

Needs to be rebased on master once #10 gets merged.