### PR TITLE
Shorten stdout in when unit test fails

### DIFF
--- a/test/unit/modules/common/sensu_go_object.py
+++ b/test/unit/modules/common/sensu_go_object.py
@@ -10,7 +10,7 @@ import pytest
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 
 from .utils import (
-    ModuleTestCase, set_module_args, AnsibleFailJson, AnsibleExitJson, patch
+    set_module_args, AnsibleFailJson, AnsibleExitJson, patch
 )
 
 

--- a/test/unit/modules/test_sensu_go_asset.py
+++ b/test/unit/modules/test_sensu_go_asset.py
@@ -9,10 +9,9 @@ from .common.utils import ModuleTestCase, generate_name
 from .common.sensu_go_object import TestSensuGoObjectBase
 
 
-class TestSensuAssetModule(ModuleTestCase, TestSensuGoObjectBase):
+class TestSensuGoAsset(ModuleTestCase, TestSensuGoObjectBase):
     module = sensu_go_asset
-
-    @pytest.mark.parametrize('test_data', [
+    matrix = [
         dict(
             name='Test unreachable URL',
             params={
@@ -190,6 +189,8 @@ class TestSensuAssetModule(ModuleTestCase, TestSensuGoObjectBase):
                 'headers': {'X-Test': 'Test'}
             }
         ),
-    ], ids=generate_name)
-    def test_asset_module(self, test_data):
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
         self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_asset_info.py
+++ b/test/unit/modules/test_sensu_go_asset_info.py
@@ -9,10 +9,9 @@ from .common.utils import ModuleTestCase, generate_name
 from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
 
 
-class TestSensuAssetModule(ModuleTestCase, TestSensuGoObjectInfoBase):
+class TestSensuGoAssetInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
     module = sensu_go_asset_info
-
-    @pytest.mark.parametrize('test_data', [
+    matrix = [
         dict(
             name='Fetch specific asset',
             params={
@@ -60,6 +59,8 @@ class TestSensuAssetModule(ModuleTestCase, TestSensuGoObjectInfoBase):
             expect_api_url='/api/core/v2/namespaces/default/assets/test_asset',
             existing_object={'name': 'test_asset'}
         ),
-    ], ids=generate_name)
-    def test_asset_info_module(self, test_data):
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
         self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_check.py
+++ b/test/unit/modules/test_sensu_go_check.py
@@ -9,10 +9,9 @@ from .common.utils import ModuleTestCase, generate_name
 from .common.sensu_go_object import TestSensuGoObjectBase
 
 
-class TestSensuCheckModule(ModuleTestCase, TestSensuGoObjectBase):
+class TestSensuGoCheck(ModuleTestCase, TestSensuGoObjectBase):
     module = sensu_go_check
-
-    @pytest.mark.parametrize('test_data', [
+    matrix = [
         dict(
             name='Test unreachable URL',
             params={
@@ -518,6 +517,8 @@ class TestSensuCheckModule(ModuleTestCase, TestSensuGoObjectBase):
                 'round_robin': True
             }
         ),
-    ], ids=generate_name)
-    def test_check_module(self, test_data):
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
         self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_filter.py
+++ b/test/unit/modules/test_sensu_go_filter.py
@@ -9,10 +9,9 @@ from .common.utils import ModuleTestCase, generate_name
 from .common.sensu_go_object import TestSensuGoObjectBase
 
 
-class TestSensuFilterModule(ModuleTestCase, TestSensuGoObjectBase):
+class TestSensuGoFilter(ModuleTestCase, TestSensuGoObjectBase):
     module = sensu_go_filter
-
-    @pytest.mark.parametrize('test_data', [
+    matrix = [
         dict(
             name='Test unreachable URL',
             params={
@@ -240,6 +239,8 @@ class TestSensuFilterModule(ModuleTestCase, TestSensuGoObjectBase):
                 'runtime_assets': ['ruby-2.4.4']
             }
         ),
-    ], ids=generate_name)
-    def test_filter_module(self, test_data):
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
         self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_mutator.py
+++ b/test/unit/modules/test_sensu_go_mutator.py
@@ -9,10 +9,9 @@ from .common.utils import ModuleTestCase, generate_name
 from .common.sensu_go_object import TestSensuGoObjectBase
 
 
-class TestSensuMutatorModule(ModuleTestCase, TestSensuGoObjectBase):
+class TestSensuGoMutator(ModuleTestCase, TestSensuGoObjectBase):
     module = sensu_go_mutator
-
-    @pytest.mark.parametrize('test_data', [
+    matrix = [
         dict(
             name='Test unreachable URL',
             params={
@@ -254,6 +253,8 @@ class TestSensuMutatorModule(ModuleTestCase, TestSensuGoObjectBase):
                 'runtime_assets': ["ruby-2.5.0"]
             }
         ),
-    ], ids=generate_name)
-    def test_mutator_module(self, test_data):
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
         self.run_test_case(test_data)


### PR DESCRIPTION
When a specific test fails, pytest would print out entire failing test case, together with entire `.parametrize()` stanza verbatim as provided in the test file. But this is quite unreadable since our matrix (that we feed to the `.parametrize()` stanza) is quite big.

With this commit we therefore extract the matrix definition into its own variable so that when a specific test fails only short section is printed to stdout, without matrix content. Namely:

```
@pytest.mark.parametrize('test_data', matrix, ids=generate_name)
    def test_module(self, test_data):
        self.run_test_case(test_data)
```