### PR TITLE
Unit test info modules

### DIFF
--- a/plugins/modules/sensu_go_event_info.py
+++ b/plugins/modules/sensu_go_event_info.py
@@ -22,7 +22,7 @@ extends_documentation_fragment:
   - sensu.sensu_go.base
   - sensu.sensu_go.info
 options:
-  name:
+  check:
     description:
       - Limit results to a specific check.
       - C(entity) must also be specified.
@@ -59,7 +59,7 @@ def main():
     argspec = sensu_argument_spec()
     argspec.update(
         dict(
-            name=dict(),
+            check=dict(),
             entity=dict(),
         )
     )
@@ -67,13 +67,13 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=argspec,
-        required_by={'name': ['entity']},
+        required_by={'check': ['entity']},
     )
 
     client = AnsibleSensuClient(module)
 
-    if module.params['name']:
-        result = [client.get('/events/{0}/{1}'.format(module.params['entity'], module.params['name']))]
+    if module.params['check']:
+        result = [client.get('/events/{0}/{1}'.format(module.params['entity'], module.params['check']))]
     elif module.params['entity']:
         result = client.get('/events/{0}'.format(module.params['entity']))
     else:

--- a/test/unit/modules/common/sensu_go_object_info.py
+++ b/test/unit/modules/common/sensu_go_object_info.py
@@ -31,12 +31,18 @@ class TestSensuGoObjectInfoBase(object):
                 self.module.main()
             result = context.value.args[0]
 
-            assert result[test_case['expect_result_key']] == test_case['expect_result']
+            assert result[test_case['expect_result_key']] == test_case['expect_result'], \
+                '{} != {}'.format(result[test_case['expect_result_key']], test_case['expect_result'])
             if len(open_url_mock.call_args_list) == 2:
                 api_url = open_url_mock.call_args_list[1][0][0]
-                assert api_url == self._build_url(test_case)
-            else:
+                kwrd_args = open_url_mock.call_args_list[1][1]
+                assert kwrd_args['method'] == 'GET', 'only GET method expected for info modules'
+                assert api_url == self._build_url(test_case), '{} != {}'.format(api_url, self._build_url(test_case))
+            elif len(open_url_mock.call_args_list) == 1:
                 assert False, 'no API call was performed'
+            else:
+                assert False, 'too many API calls were performed'
+            assert result['changed'] is False, 'info module should not change anything'
 
     def _extend_default_test_case(self, test_case):
         merged_test_case = self.default_test_case.copy()

--- a/test/unit/modules/test_sensu_go_asset_info.py
+++ b/test/unit/modules/test_sensu_go_asset_info.py
@@ -33,15 +33,15 @@ class TestSensuGoAssetInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
         dict(
             name='Fetch unexisting asset',
             params={
-                'name': 'test_asset'
+                'name': 'unexisting'
             },
             expect_result_key='assets',
             expect_result=[{}],
-            expect_api_url='/api/core/v2/namespaces/default/assets/test_asset',
+            expect_api_url='/api/core/v2/namespaces/default/assets/unexisting',
             existing_object={}
         ),
         dict(
-            name='Fetch unexisting assets',
+            name='Fetch zero assets',
             params={},
             expect_result_key='assets',
             expect_result=[],
@@ -49,7 +49,7 @@ class TestSensuGoAssetInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
             existing_object=[]
         ),
         dict(
-            name='(check) Test fetch assets',
+            name='(check) Test fetch asset',
             params={
                 'name': 'test_asset'
             },

--- a/test/unit/modules/test_sensu_go_check_info.py
+++ b/test/unit/modules/test_sensu_go_check_info.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_check_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoCheckInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_check_info
+    matrix = [
+        dict(
+            name='Fetch specific check',
+            params={
+                'name': 'test_check'
+            },
+            expect_result_key='checks',
+            expect_result=[{'name': 'test_check'}],
+            expect_api_url='/api/core/v2/namespaces/default/checks/test_check',
+            existing_object={'name': 'test_check'}
+        ),
+        dict(
+            name='Fetch multiple checks',
+            params={},
+            expect_result_key='checks',
+            expect_result=[{'name': 'test_check'}, {'name': 'test_check2'}],
+            expect_api_url='/api/core/v2/namespaces/default/checks',
+            existing_object=[{'name': 'test_check'}, {'name': 'test_check2'}]
+        ),
+        dict(
+            name='Fetch unexisting check',
+            params={
+                'name': 'unexisting'
+            },
+            expect_result_key='checks',
+            expect_result=[{}],
+            expect_api_url='/api/core/v2/namespaces/default/checks/unexisting',
+            existing_object={}
+        ),
+        dict(
+            name='Fetch zero checks',
+            params={},
+            expect_result_key='checks',
+            expect_result=[],
+            expect_api_url='/api/core/v2/namespaces/default/checks',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch check',
+            params={
+                'name': 'test_check'
+            },
+            check_mode=True,
+            expect_result_key='checks',
+            expect_result=[{'name': 'test_check'}],
+            expect_api_url='/api/core/v2/namespaces/default/checks/test_check',
+            existing_object={'name': 'test_check'}
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_cluster_info.py
+++ b/test/unit/modules/test_sensu_go_cluster_info.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_cluster_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoClusterInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_cluster_info
+    matrix = [
+        dict(
+            name='Fetch cluster members',
+            params={},
+            expect_result_key='cluster',
+            expect_result=[{'name': 'member'}, {'name': 'member2'}],
+            expect_api_url='/api/core/v2/cluster/members',
+            existing_object=[{'name': 'member'}, {'name': 'member2'}]
+        ),
+        dict(
+            name='Fetch zero cluster members',
+            params={},
+            expect_result_key='cluster',
+            expect_result=[],
+            expect_api_url='/api/core/v2/cluster/members',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch cluster members',
+            params={},
+            check_mode=True,
+            expect_result_key='cluster',
+            expect_result=[{'name': 'member'}],
+            expect_api_url='/api/core/v2/cluster/members',
+            existing_object=[{'name': 'member'}]
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_entity_info.py
+++ b/test/unit/modules/test_sensu_go_entity_info.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_entity_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoEntityInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_entity_info
+    matrix = [
+        dict(
+            name='Fetch specific entity',
+            params={
+                'name': 'test_entity'
+            },
+            expect_result_key='entities',
+            expect_result=[{'name': 'test_entity'}],
+            expect_api_url='/api/core/v2/namespaces/default/entities/test_entity',
+            existing_object={'name': 'test_entity'}
+        ),
+        dict(
+            name='Fetch multiple entities',
+            params={},
+            expect_result_key='entities',
+            expect_result=[{'name': 'test_entity'}, {'name': 'test_entity2'}],
+            expect_api_url='/api/core/v2/namespaces/default/entities',
+            existing_object=[{'name': 'test_entity'}, {'name': 'test_entity2'}]
+        ),
+        dict(
+            name='Fetch unexisting entity',
+            params={
+                'name': 'unexisting'
+            },
+            expect_result_key='entities',
+            expect_result=[{}],
+            expect_api_url='/api/core/v2/namespaces/default/entities/unexisting',
+            existing_object={}
+        ),
+        dict(
+            name='Fetch zero entities',
+            params={},
+            expect_result_key='entities',
+            expect_result=[],
+            expect_api_url='/api/core/v2/namespaces/default/entities',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch entitiy',
+            params={
+                'name': 'test_entity'
+            },
+            check_mode=True,
+            expect_result_key='entities',
+            expect_result=[{'name': 'test_entity'}],
+            expect_api_url='/api/core/v2/namespaces/default/entities/test_entity',
+            existing_object={'name': 'test_entity'}
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_event_info.py
+++ b/test/unit/modules/test_sensu_go_event_info.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_event_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoEventInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_event_info
+    matrix = [
+        dict(
+            name='Fetch all events',
+            params={},
+            expect_result_key='events',
+            expect_result=[{'name': 'test_event'}],
+            expect_api_url='/api/core/v2/namespaces/default/events',
+            existing_object=[{'name': 'test_event'}]
+        ),
+        dict(
+            name='Fetch all events by entity',
+            params={
+                'entity': 'test_entity'
+            },
+            expect_result_key='events',
+            expect_result=[{'name': 'test_event'}],
+            expect_api_url='/api/core/v2/namespaces/default/events/test_entity',
+            existing_object=[{'name': 'test_event'}]
+        ),
+        dict(
+            name='Fetch all events by entity and check',
+            params={
+                'entity': 'test_entity',
+                'check': 'test_check',
+            },
+            expect_result_key='events',
+            expect_result=[{'name': 'test_event'}],
+            expect_api_url='/api/core/v2/namespaces/default/events/test_entity/test_check',
+            existing_object={'name': 'test_event'}
+        ),
+        dict(
+            name='Fetch zero events',
+            params={},
+            expect_result_key='events',
+            expect_result=[],
+            expect_api_url='/api/core/v2/namespaces/default/events',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch event',
+            params={},
+            check_mode=True,
+            expect_result_key='events',
+            expect_result=[{'name': 'test_event'}],
+            expect_api_url='/api/core/v2/namespaces/default/events',
+            existing_object=[{'name': 'test_event'}]
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_filter_info.py
+++ b/test/unit/modules/test_sensu_go_filter_info.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_filter_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoFilterInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_filter_info
+    matrix = [
+        dict(
+            name='Fetch specific filter',
+            params={
+                'name': 'test_filter'
+            },
+            expect_result_key='filters',
+            expect_result=[{'name': 'test_filter'}],
+            expect_api_url='/api/core/v2/namespaces/default/filters/test_filter',
+            existing_object={'name': 'test_filter'}
+        ),
+        dict(
+            name='Fetch multiple filters',
+            params={},
+            expect_result_key='filters',
+            expect_result=[{'name': 'test_filter'}, {'name': 'test_filter2'}],
+            expect_api_url='/api/core/v2/namespaces/default/filters',
+            existing_object=[{'name': 'test_filter'}, {'name': 'test_filter2'}]
+        ),
+        dict(
+            name='Fetch unexisting filter',
+            params={
+                'name': 'unexisting'
+            },
+            expect_result_key='filters',
+            expect_result=[{}],
+            expect_api_url='/api/core/v2/namespaces/default/filters/unexisting',
+            existing_object={}
+        ),
+        dict(
+            name='Fetch zero filters',
+            params={},
+            expect_result_key='filters',
+            expect_result=[],
+            expect_api_url='/api/core/v2/namespaces/default/filters',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch filter',
+            params={
+                'name': 'test_filter'
+            },
+            check_mode=True,
+            expect_result_key='filters',
+            expect_result=[{'name': 'test_filter'}],
+            expect_api_url='/api/core/v2/namespaces/default/filters/test_filter',
+            existing_object={'name': 'test_filter'}
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_handler_info.py
+++ b/test/unit/modules/test_sensu_go_handler_info.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_handler_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoHandlerInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_handler_info
+    matrix = [
+        dict(
+            name='Fetch specific handler',
+            params={
+                'name': 'test_handler'
+            },
+            expect_result_key='handlers',
+            expect_result=[{'name': 'test_handler'}],
+            expect_api_url='/api/core/v2/namespaces/default/handlers/test_handler',
+            existing_object={'name': 'test_handler'}
+        ),
+        dict(
+            name='Fetch multiple handlers',
+            params={},
+            expect_result_key='handlers',
+            expect_result=[{'name': 'test_handler'}, {'name': 'test_handler2'}],
+            expect_api_url='/api/core/v2/namespaces/default/handlers',
+            existing_object=[{'name': 'test_handler'}, {'name': 'test_handler2'}]
+        ),
+        dict(
+            name='Fetch unexisting handler',
+            params={
+                'name': 'unexisting'
+            },
+            expect_result_key='handlers',
+            expect_result=[{}],
+            expect_api_url='/api/core/v2/namespaces/default/handlers/unexisting',
+            existing_object={}
+        ),
+        dict(
+            name='Fetch zero handlers',
+            params={},
+            expect_result_key='handlers',
+            expect_result=[],
+            expect_api_url='/api/core/v2/namespaces/default/handlers',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch handler',
+            params={
+                'name': 'test_handler'
+            },
+            check_mode=True,
+            expect_result_key='handlers',
+            expect_result=[{'name': 'test_handler'}],
+            expect_api_url='/api/core/v2/namespaces/default/handlers/test_handler',
+            existing_object={'name': 'test_handler'}
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_hook_info.py
+++ b/test/unit/modules/test_sensu_go_hook_info.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_hook_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoHookInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_hook_info
+    matrix = [
+        dict(
+            name='Fetch specific hook',
+            params={
+                'name': 'test_hook'
+            },
+            expect_result_key='hooks',
+            expect_result=[{'name': 'test_hook'}],
+            expect_api_url='/api/core/v2/namespaces/default/hooks/test_hook',
+            existing_object={'name': 'test_hook'}
+        ),
+        dict(
+            name='Fetch multiple hooks',
+            params={},
+            expect_result_key='hooks',
+            expect_result=[{'name': 'test_hook'}, {'name': 'test_hook2'}],
+            expect_api_url='/api/core/v2/namespaces/default/hooks',
+            existing_object=[{'name': 'test_hook'}, {'name': 'test_hook2'}]
+        ),
+        dict(
+            name='Fetch unexisting hook',
+            params={
+                'name': 'unexisting'
+            },
+            expect_result_key='hooks',
+            expect_result=[{}],
+            expect_api_url='/api/core/v2/namespaces/default/hooks/unexisting',
+            existing_object={}
+        ),
+        dict(
+            name='Fetch zero hooks',
+            params={},
+            expect_result_key='hooks',
+            expect_result=[],
+            expect_api_url='/api/core/v2/namespaces/default/hooks',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch hook',
+            params={
+                'name': 'test_hook'
+            },
+            check_mode=True,
+            expect_result_key='hooks',
+            expect_result=[{'name': 'test_hook'}],
+            expect_api_url='/api/core/v2/namespaces/default/hooks/test_hook',
+            existing_object={'name': 'test_hook'}
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_mutator_info.py
+++ b/test/unit/modules/test_sensu_go_mutator_info.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_mutator_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoMutatorInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_mutator_info
+    matrix = [
+        dict(
+            name='Fetch specific mutator',
+            params={
+                'name': 'test_mutator'
+            },
+            expect_result_key='mutators',
+            expect_result=[{'name': 'test_mutator'}],
+            expect_api_url='/api/core/v2/namespaces/default/mutators/test_mutator',
+            existing_object={'name': 'test_mutator'}
+        ),
+        dict(
+            name='Fetch multiple mutators',
+            params={},
+            expect_result_key='mutators',
+            expect_result=[{'name': 'test_mutator'}, {'name': 'test_mutator2'}],
+            expect_api_url='/api/core/v2/namespaces/default/mutators',
+            existing_object=[{'name': 'test_mutator'}, {'name': 'test_mutator2'}]
+        ),
+        dict(
+            name='Fetch unexisting mutator',
+            params={
+                'name': 'unexisting'
+            },
+            expect_result_key='mutators',
+            expect_result=[{}],
+            expect_api_url='/api/core/v2/namespaces/default/mutators/unexisting',
+            existing_object={}
+        ),
+        dict(
+            name='Fetch zero mutators',
+            params={},
+            expect_result_key='mutators',
+            expect_result=[],
+            expect_api_url='/api/core/v2/namespaces/default/mutators',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch mutator',
+            params={
+                'name': 'test_mutator'
+            },
+            check_mode=True,
+            expect_result_key='mutators',
+            expect_result=[{'name': 'test_mutator'}],
+            expect_api_url='/api/core/v2/namespaces/default/mutators/test_mutator',
+            existing_object={'name': 'test_mutator'}
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_namespace_info.py
+++ b/test/unit/modules/test_sensu_go_namespace_info.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_namespace_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoNamespaceInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_namespace_info
+    matrix = [
+        dict(
+            name='Fetch multiple namespaces',
+            params={},
+            expect_result_key='namespaces',
+            expect_result=['test_namespace', 'test_namespace2'],
+            expect_api_url='/api/core/v2/namespaces',
+            existing_object=[{'name': 'test_namespace'}, {'name': 'test_namespace2'}]
+        ),
+        dict(
+            name='Fetch zero namespaces',
+            params={},
+            expect_result_key='namespaces',
+            expect_result=[],
+            expect_api_url='/api/core/v2/namespaces',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch namespaces',
+            params={},
+            check_mode=True,
+            expect_result_key='namespaces',
+            expect_result=['test_namespace'],
+            expect_api_url='/api/core/v2/namespaces',
+            existing_object=[{'name': 'test_namespace'}]
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_rolebinding_info.py
+++ b/test/unit/modules/test_sensu_go_rolebinding_info.py
@@ -1,0 +1,120 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_rolebinding_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoRolebindingInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_rolebinding_info
+    matrix = [
+        dict(
+            name='Fetch specific rolebinding (namespaced)',
+            params={
+                'name': 'test_binding'
+            },
+            expect_result_key='rolebindings',
+            expect_result=[{'name': 'test_binding'}],
+            expect_api_url='/api/core/v2/namespaces/default/rolebindings/test_binding',
+            existing_object={'name': 'test_binding'}
+        ),
+        dict(
+            name='Fetch specific rolebinding (cluster-wide)',
+            params={
+                'name': 'test_binding',
+                'cluster': 'yes'
+            },
+            expect_result_key='rolebindings',
+            expect_result=[{'name': 'test_binding'}],
+            expect_api_url='/api/core/v2/clusterrolebindings/test_binding',
+            existing_object={'name': 'test_binding'}
+        ),
+        dict(
+            name='Fetch multiple rolebinding (namespaced)',
+            params={},
+            expect_result_key='rolebindings',
+            expect_result=[{'name': 'test_binding'}, {'name': 'test_binding2'}],
+            expect_api_url='/api/core/v2/namespaces/default/rolebindings',
+            existing_object=[{'name': 'test_binding'}, {'name': 'test_binding2'}]
+        ),
+        dict(
+            name='Fetch multiple rolebinding (cluster-wide)',
+            params={
+                'cluster': 'yes'
+            },
+            expect_result_key='rolebindings',
+            expect_result=[{'name': 'test_binding'}, {'name': 'test_binding2'}],
+            expect_api_url='/api/core/v2/clusterrolebindings',
+            existing_object=[{'name': 'test_binding'}, {'name': 'test_binding2'}]
+        ),
+        dict(
+            name='Fetch unexisting rolebinding (namespaced)',
+            params={
+                'name': 'unexisting'
+            },
+            expect_result_key='rolebindings',
+            expect_result=[{}],
+            expect_api_url='/api/core/v2/namespaces/default/rolebindings/unexisting',
+            existing_object={}
+        ),
+        dict(
+            name='Fetch unexisting rolebinding (cluster-wide)',
+            params={
+                'name': 'unexisting',
+                'cluster': 'yes'
+            },
+            expect_result_key='rolebindings',
+            expect_result=[{}],
+            expect_api_url='/api/core/v2/clusterrolebindings/unexisting',
+            existing_object={}
+        ),
+        dict(
+            name='Fetch zero rolebindings (namespaced)',
+            params={},
+            expect_result_key='rolebindings',
+            expect_result=[],
+            expect_api_url='/api/core/v2/namespaces/default/rolebindings',
+            existing_object=[]
+        ),
+        dict(
+            name='Fetch zero rolebindings (cluster-wide)',
+            params={
+                'cluster': 'yes'
+            },
+            expect_result_key='rolebindings',
+            expect_result=[],
+            expect_api_url='/api/core/v2/clusterrolebindings',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch rolebindig (namespaced)',
+            params={
+                'name': 'test_binding'
+            },
+            check_mode=True,
+            expect_result_key='rolebindings',
+            expect_result=[{'name': 'test_binding'}],
+            expect_api_url='/api/core/v2/namespaces/default/rolebindings/test_binding',
+            existing_object={'name': 'test_binding'}
+        ),
+        dict(
+            name='(check) Test fetch rolebindig (cluster-wide)',
+            params={
+                'name': 'test_binding',
+                'cluster': 'yes'
+            },
+            check_mode=True,
+            expect_result_key='rolebindings',
+            expect_result=[{'name': 'test_binding'}],
+            expect_api_url='/api/core/v2/clusterrolebindings/test_binding',
+            existing_object={'name': 'test_binding'}
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_silence_info.py
+++ b/test/unit/modules/test_sensu_go_silence_info.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_silence_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoSilenceInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_silence_info
+    matrix = [
+        dict(
+            name='Fetch specific silenced',
+            params={
+                'name': 'test_silenced'
+            },
+            expect_result_key='silenced',
+            expect_result=[{'name': 'test_silenced'}],
+            expect_api_url='/api/core/v2/namespaces/default/silenced/test_silenced',
+            existing_object={'name': 'test_silenced'}
+        ),
+        dict(
+            name='Fetch all silenced',
+            params={},
+            expect_result_key='silenced',
+            expect_result=[{'name': 'test_silenced'}],
+            expect_api_url='/api/core/v2/namespaces/default/silenced',
+            existing_object=[{'name': 'test_silenced'}]
+        ),
+        dict(
+            name='Fetch silenced per subscription',
+            params={
+                'subscription': 'test_subscription'
+            },
+            expect_result_key='silenced',
+            expect_result=[{'name': 'test_silenced'}],
+            expect_api_url='/api/core/v2/namespaces/default/silenced/subscriptions/test_subscription',
+            existing_object=[{'name': 'test_silenced'}]
+        ),
+        dict(
+            name='Fetch silenced per check',
+            params={
+                'check': 'test_check'
+            },
+            expect_result_key='silenced',
+            expect_result=[{'name': 'test_silenced'}],
+            expect_api_url='/api/core/v2/namespaces/default/silenced/checks/test_check',
+            existing_object=[{'name': 'test_silenced'}]
+        ),
+        dict(
+            name='(check) Test fetch all silenced',
+            params={},
+            check_mode=True,
+            expect_result_key='silenced',
+            expect_result=[{'name': 'test_silenced'}],
+            expect_api_url='/api/core/v2/namespaces/default/silenced',
+            existing_object=[{'name': 'test_silenced'}]
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)

--- a/test/unit/modules/test_sensu_go_user_info.py
+++ b/test/unit/modules/test_sensu_go_user_info.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.modules import sensu_go_user_info
+
+from .common.utils import ModuleTestCase, generate_name
+from .common.sensu_go_object_info import TestSensuGoObjectInfoBase
+
+
+class TestSensuGoUserInfo(ModuleTestCase, TestSensuGoObjectInfoBase):
+    module = sensu_go_user_info
+    matrix = [
+        dict(
+            name='Fetch specific user',
+            params={
+                'name': 'test_user'
+            },
+            expect_result_key='users',
+            expect_result=[{'name': 'test_user'}],
+            expect_api_url='/api/core/v2/users/test_user',
+            existing_object={'name': 'test_user'}
+        ),
+        dict(
+            name='Fetch multiple users',
+            params={},
+            expect_result_key='users',
+            expect_result=[{'name': 'test_user'}, {'name': 'test_user2'}],
+            expect_api_url='/api/core/v2/users',
+            existing_object=[{'name': 'test_user'}, {'name': 'test_user2'}]
+        ),
+        dict(
+            name='Fetch unexisting user',
+            params={
+                'name': 'unexisting'
+            },
+            expect_result_key='users',
+            expect_result=[{}],
+            expect_api_url='/api/core/v2/users/unexisting',
+            existing_object={}
+        ),
+        dict(
+            name='Fetch zero users',
+            params={},
+            expect_result_key='users',
+            expect_result=[],
+            expect_api_url='/api/core/v2/users',
+            existing_object=[]
+        ),
+        dict(
+            name='(check) Test fetch users',
+            params={
+                'name': 'test_user'
+            },
+            check_mode=True,
+            expect_result_key='users',
+            expect_result=[{'name': 'test_user'}],
+            expect_api_url='/api/core/v2/users/test_user',
+            existing_object={'name': 'test_user'}
+        ),
+    ]
+
+    @pytest.mark.parametrize('test_data', matrix, ids=generate_name)
+    def test_module(self, test_data):
+        self.run_test_case(test_data)


### PR DESCRIPTION
Info modules are easiest to test because we only need to check GET values. Therefore we implement most of them in one take.