### PR TITLE
check_info has no `name` parameter

### DIFF
--- a/plugins/modules/sensu_go_event_info.py
+++ b/plugins/modules/sensu_go_event_info.py
@@ -20,7 +20,6 @@ description:
 version_added: 0.1.0
 extends_documentation_fragment:
   - sensu.sensu_go.base
-  - sensu.sensu_go.info
 options:
   check:
     description:


### PR DESCRIPTION
We were extending sens_go.info doc part which listed name as a parameter. But this is wrong because name is not a valid parameter for this module.