### PR TITLE
Make sure all sanity tests pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,6 @@ jobs:
       - common_setup
       - run_test:
           kind: sanity
-          args: --test pep8
 
   unit_test_python27:
     executor: python27

--- a/plugins/modules/sensu_go_asset.py
+++ b/plugins/modules/sensu_go_asset.py
@@ -51,7 +51,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: create asset
+- name: Create asset
   sensu_go_asset:
     name: asset
     download_url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz

--- a/plugins/modules/sensu_go_asset_info.py
+++ b/plugins/modules/sensu_go_asset_info.py
@@ -33,7 +33,7 @@ RETURN = '''
 assets:
   description: list of Sensu assets
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sensu_go_check_info.py
+++ b/plugins/modules/sensu_go_check_info.py
@@ -33,7 +33,7 @@ RETURN = '''
 checks:
   description: list of Sensu checks
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sensu_go_entity.py
+++ b/plugins/modules/sensu_go_entity.py
@@ -45,8 +45,8 @@ options:
 '''
 
 EXAMPLES = '''
-# Create a proxy entity
-- sensu_go_entity:
+- name: Create a proxy entity
+  sensu_go_entity:
     name: api.example.com
     subscriptions:
       - tls
@@ -54,8 +54,8 @@ EXAMPLES = '''
       labels:
         Status: production
 
-# Modify an agent entity
-- sensu_go_entity:
+- name: Modify an agent entity
+  sensu_go_entity:
     name: api-server-01.example.com
     entity_class: agent
     labels:

--- a/plugins/modules/sensu_go_entity_info.py
+++ b/plugins/modules/sensu_go_entity_info.py
@@ -24,8 +24,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-# List all entities
-- name: List Sensu entities
+- name: List all Sensu entities
   sensu_go_entity_info:
   register: result
 '''

--- a/plugins/modules/sensu_go_event_info.py
+++ b/plugins/modules/sensu_go_event_info.py
@@ -47,7 +47,7 @@ RETURN = '''
 events:
   description: list of Sensu events
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sensu_go_filter_info.py
+++ b/plugins/modules/sensu_go_filter_info.py
@@ -33,7 +33,7 @@ RETURN = '''
 filters:
   description: list of Sensu filters
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sensu_go_handler.py
+++ b/plugins/modules/sensu_go_handler.py
@@ -69,16 +69,17 @@ options:
 '''
 
 EXAMPLES = '''
-sensu_go_handler:
-  name: influx-db
-  type: pipe
-  command: sensu-influxdb-handler -d sensu
-  env_vars:
-    INFLUXDB_ADDR: http://influxdb.default.svc.cluster.local:8086
-    INFLUXDB_USER: sensu
-    INFLUXDB_PASS: password
-  runtime_assets:
-    - sensu-influxdb-handler
+- name: Setup InfluxDB handler
+  sensu_go_handler:
+    name: influx-db
+    type: pipe
+    command: sensu-influxdb-handler -d sensu
+    env_vars:
+      INFLUXDB_ADDR: http://influxdb.default.svc.cluster.local:8086
+      INFLUXDB_USER: sensu
+      INFLUXDB_PASS: password
+    runtime_assets:
+      - sensu-influxdb-handler
 '''
 
 RETURN = '''

--- a/plugins/modules/sensu_go_handler_info.py
+++ b/plugins/modules/sensu_go_handler_info.py
@@ -33,7 +33,7 @@ RETURN = '''
 handlers:
   description: list of Sensu handlers
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sensu_go_hook_info.py
+++ b/plugins/modules/sensu_go_hook_info.py
@@ -33,7 +33,7 @@ RETURN = '''
 hooks:
   description: list of Sensu hooks
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sensu_go_mutator_info.py
+++ b/plugins/modules/sensu_go_mutator_info.py
@@ -33,7 +33,7 @@ RETURN = '''
 mutators:
   description: list of Sensu mutators
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sensu_go_namespace.py
+++ b/plugins/modules/sensu_go_namespace.py
@@ -38,13 +38,13 @@ options:
 '''
 
 EXAMPLES = '''
-# Create a new namespace
-- sensu_go_namespace:
+- name: Create a new namespace
+  sensu_go_namespace:
     name: production
     state: present
 
-# Delete a namespace
-- sensu_go_namespace:
+- name: Delete a namespace
+  sensu_go_namespace:
     name: staging
     state: absent
 '''

--- a/plugins/modules/sensu_go_namespace_info.py
+++ b/plugins/modules/sensu_go_namespace_info.py
@@ -32,7 +32,7 @@ RETURN = '''
 namespaces:
   description: list of Sensu namespaces
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sensu_go_role_info.py
+++ b/plugins/modules/sensu_go_role_info.py
@@ -39,7 +39,7 @@ RETURN = '''
 roles:
   description: list of Sensu roles
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sensu_go_silence.py
+++ b/plugins/modules/sensu_go_silence.py
@@ -46,13 +46,13 @@ options:
 '''
 
 EXAMPLES = '''
-# Silence a specific check
-sensu_go_silence:
-  name: Class_mx:check-disk
+- name: Silence a specific check
+  sensu_go_silence:
+    name: Class_mx:check-disk
 
-# Silence all checks on a specific host
-sensu_go_silence:
-  name: entity:punk-zenfusho.mx.x.mail.umich.edu:*
+- name: Silence all checks on a specific host
+  sensu_go_silence:
+    name: entity:punk-zenfusho.mx.x.mail.umich.edu:*
 '''
 
 RETURN = '''

--- a/plugins/modules/sensu_go_silence_info.py
+++ b/plugins/modules/sensu_go_silence_info.py
@@ -33,7 +33,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: List Sensu silence entrues
+- name: List Sensu silence entries
   sensu_go_silence_info:
   register: result
 '''
@@ -42,7 +42,7 @@ RETURN = '''
 silence_entries:
   description: list of Sensu silence entries
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sensu_go_user_info.py
+++ b/plugins/modules/sensu_go_user_info.py
@@ -33,7 +33,7 @@ RETURN = '''
 users:
   description: list of Sensu users
   returned: always
-  type: complex
+  type: list
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/test/unit/modules/common/sensu_go_object.py
+++ b/test/unit/modules/common/sensu_go_object.py
@@ -106,7 +106,10 @@ class TestSensuGoObjectBase(object):
     def _build_url(self, test_case):
         has_hostname = re.match('(?:http|ftp|https)://', test_case['expect_api_url'])
         if not has_hostname:
-            return '{}{}'.format(test_case['params']['url'], test_case['expect_api_url'])
+            return '{url}{api}'.format(
+                url=test_case['params']['url'],
+                api=test_case['expect_api_url'],
+            )
         return test_case['expect_api_url']
 
     def _parse_mock_call(self, mock_call):

--- a/test/unit/modules/common/sensu_go_object_info.py
+++ b/test/unit/modules/common/sensu_go_object_info.py
@@ -32,12 +32,12 @@ class TestSensuGoObjectInfoBase(object):
             result = context.value.args[0]
 
             assert result[test_case['expect_result_key']] == test_case['expect_result'], \
-                '{} != {}'.format(result[test_case['expect_result_key']], test_case['expect_result'])
+                '{0} != {1}'.format(result[test_case['expect_result_key']], test_case['expect_result'])
             if len(open_url_mock.call_args_list) == 2:
                 api_url = open_url_mock.call_args_list[1][0][0]
                 kwrd_args = open_url_mock.call_args_list[1][1]
                 assert kwrd_args['method'] == 'GET', 'only GET method expected for info modules'
-                assert api_url == self._build_url(test_case), '{} != {}'.format(api_url, self._build_url(test_case))
+                assert api_url == self._build_url(test_case), '{0} != {1}'.format(api_url, self._build_url(test_case))
             elif len(open_url_mock.call_args_list) == 1:
                 assert False, 'no API call was performed'
             else:
@@ -65,7 +65,10 @@ class TestSensuGoObjectInfoBase(object):
     def _build_url(self, test_case):
         has_hostname = re.match('(?:http|ftp|https)://', test_case['expect_api_url'])
         if not has_hostname:
-            return '{}{}'.format(test_case['params']['url'], test_case['expect_api_url'])
+            return '{url}{api}'.format(
+                url=test_case['params']['url'],
+                api=test_case['expect_api_url'],
+            )
         return test_case['expect_api_url']
 
     def _prepare_input_params(self, test_case):


### PR DESCRIPTION
Up until now, we only ran pep8 tests that failed to detect other significant issues in our code. This commit cleans up the sources enough to keep the sanity checker happy and enables full sanity check.