### PR TITLE
Detailed coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,14 @@ commands:
           command: |
             cd ${HOME}/.ansible/collections/ansible_collections/sensu/sensu_go
             ansible-test coverage report --all
+      - run:
+          name: Report coverage details as HTML
+          command: |
+            cd ${HOME}/.ansible/collections/ansible_collections/sensu/sensu_go
+            ansible-test coverage html --all
+      - store_artifacts:
+          path: /home/circleci/.ansible/collections/ansible_collections/sensu/sensu_go/test/results/reports/coverage
+          destination: coverage-report
 
 jobs:
   sanity:


### PR DESCRIPTION
Currently we only report per-file coverage percentage to console which is great for coverage overview. But when you want to further increase the coverage, you need to see which lines are missed, hence
we're adding a detailed HTML coverage report as artifact.

The artifact can then be viewed from the job details page at CicleCI. I think we can keep both console report and HTML report because console report will persist for sure while artifacts are deleted at some point.