### PR TITLE
Cleanly separate module utils from Ansible internals

### DIFF
--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import env_fallback
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import client
+
+
+COMMON_ARGUMENTS = dict(
+    user=dict(
+        default="admin",
+        fallback=(env_fallback, ["SENSU_USER"]),
+    ),
+    password=dict(
+        default="P@ssw0rd!",
+        no_log=True,
+        fallback=(env_fallback, ["SENSU_PASSWORD"]),
+    ),
+    url=dict(
+        default="http://localhost:8080",
+        fallback=(env_fallback, ["SENSU_BACKEND_URL"]),
+    ),
+    namespace=dict(
+        default="default",
+    ),
+)
+
+MUTATION_ARGUMENTS = dict(
+    COMMON_ARGUMENTS,
+    state=dict(
+        default="present",
+        choices=["present", "absent"],
+    ),
+    name=dict(
+        required=True,
+    ),
+    labels=dict(
+        type="dict",
+        default={},
+    ),
+    annotations=dict(
+        type="dict",
+        default={},
+    ),
+)
+
+
+def get_mutation_payload(source, *wanted_params):
+    payload = {
+        k: source[k] for k in wanted_params if source.get(k) is not None
+    }
+    payload["metadata"] = dict(
+        name=source["name"],
+        namespace=source["namespace"],
+    )
+    for kind in "labels", "annotations":
+        if source.get(kind):
+            payload["metadata"][kind] = {
+                k: str(v) for k, v in source[kind].items()
+            }
+    return payload
+
+
+def get_sensu_client(params):
+    return client.Client(
+        params["url"], params["user"], params["password"], params["namespace"],
+    )

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import json
+
+from ansible.module_utils.urls import open_url
+from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    errors, response,
+)
+
+
+def _abort(msg, *args, **kwargs):
+    raise errors.ClientError(msg.format(*args, **kwargs))
+
+
+class Client:
+    def __init__(self, address, username, password, namespace=None):
+        self.address = address.rstrip("/")
+        self.username = username
+        self.password = password
+
+        if namespace:
+            self.url_template = "{0}/api/core/v2/namespaces/{1}{{0}}".format(
+                self.address, namespace,
+            )
+        else:
+            self.url_template = "{0}/api/core/v2{{0}}".format(self.address)
+
+        self._token = None  # Login when/if required
+
+    @property
+    def token(self):
+        if not self._token:
+            self._token = self._login()
+        return self._token
+
+    def _login(self):
+        try:
+            resp = open_url(
+                "{0}/auth".format(self.address), force_basic_auth=True,
+                url_username=self.username, url_password=self.password,
+            )
+            return json.loads(resp.read())["access_token"]
+        except URLError as e:
+            _abort("Login failed: {}", e.reason)
+
+    def request(self, method, path, payload=None):
+        arguments = dict(
+            url=self.url_template.format(path),
+            method=method,
+            headers={"Authorization": "Bearer {0}".format(self.token)},
+            data=None,
+        )
+        if payload is not None:
+            arguments["headers"]["content-type"] = "application/json"
+            arguments["data"] = json.dumps(payload)
+
+        try:
+            resp = open_url(**arguments)
+            return response.Response(resp.getcode(), resp.read())
+        except HTTPError as e:
+            # This is not an error, since client consumers might be able to
+            # work around/expect non 20x codes.
+            return response.Response(e.code, e.reason)
+        except URLError as e:
+            _abort("{} request failed: {}", method, e.reason)
+
+    def get(self, path):
+        return self.request("GET", path)
+
+    def put(self, path, payload):
+        return self.request("PUT", path, payload)
+
+    def delete(self, path):
+        return self.request("DELETE", path)

--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+class Error(Exception):
+    """ Base error that serves as a parent for all other errors. """
+
+
+class ClientError(Error):
+    """ Error that signals failure in HTTP connection. """

--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -13,3 +13,7 @@ class Error(Exception):
 
 class ClientError(Error):
     """ Error that signals failure in HTTP connection. """
+
+
+class SyncError(Error):
+    """ Error that signals failure when syncing state with remote. """

--- a/plugins/module_utils/response.py
+++ b/plugins/module_utils/response.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import json
+
+
+class Response:
+    def __init__(self, status, data):
+        self.status = status
+        self.data = data
+        try:
+            self.json = json.loads(data)
+        except ValueError:  # Cannot use JSONDecodeError here (python 2)
+            self.json = None

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import errors
+
+
+def sync(state, client, path, payload, check_mode):
+    remote_object = get(client, path)
+
+    if state == "absent" and remote_object is None:
+        return False, None
+
+    if state == "absent":
+        if not check_mode:
+            delete(client, path)
+        return True, None
+
+    # Making sure remote_object is present from here on
+
+    if do_differ(remote_object, payload):
+        if check_mode:
+            return True, payload
+        put(client, path, payload)
+        return True, get(client, path)
+
+    return False, remote_object
+
+
+def do_differ(current, desired):
+    if current is None:
+        return True
+
+    for key, value in desired.items():
+        if value != current.get(key):
+            return True
+
+    return False
+
+
+def _abort(msg, *args, **kwargs):
+    raise errors.SyncError(msg.format(*args, **kwargs))
+
+
+def get(client, path):
+    resp = client.get(path)
+    if resp.status not in (200, 404):
+        _abort(
+            "GET {0} failed with status {1}: {2}", path, resp.status, resp.data,
+        )
+    if resp.status == 200 and resp.json is None:
+        _abort("Server returned invalid JSON {0}", resp.data)
+    return resp.json
+
+
+def delete(client, path):
+    resp = client.delete(path)
+    if resp.status != 204:
+        _abort(
+            "DELETE {0} failed with status {1}: {2}",
+            path, resp.status, resp.data,
+        )
+    return None
+
+
+def put(client, path, payload):
+    resp = client.put(path, payload)
+    if resp.status != 201:
+        _abort(
+            "PUT {0} failed with status {1}: {2}",
+            path, resp.status, resp.data,
+        )
+    return None
+
+
+def dict_to_single_item_dicts(data):
+    return [{k: v} for k, v in data.items()]
+
+
+def dict_to_key_value_strings(data):
+    return ["{0}={1}".format(k, v) for k, v in data.items()]

--- a/plugins/modules/sensu_go_asset_info.py
+++ b/plugins/modules/sensu_go_asset_info.py
@@ -1,67 +1,76 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 # Copyright: (c) 2019, Paul Arthur <paul.arthur@flowerysong.com>
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 module: sensu_go_asset_info
 author: "Paul Arthur (@flowerysong)"
 short_description: Lists Sensu assets
 description:
-  - 'For more information, refer to the Sensu documentation: U(https://docs.sensu.io/sensu-go/latest/reference/assets/)'
+  - For more information, refer to the Sensu documentation at
+    U(https://docs.sensu.io/sensu-go/latest/reference/assets/)
 version_added: 0.0.1
 extends_documentation_fragment:
   - sensu.sensu_go.base
   - sensu.sensu_go.info
-'''
+"""
 
-EXAMPLES = '''
+EXAMPLES = """
 - name: List Sensu assets
   sensu_go_asset_info:
   register: result
-'''
+"""
 
-RETURN = '''
+RETURN = """
 assets:
   description: list of Sensu assets
   returned: always
   type: list
-'''
+"""
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.sensu.sensu_go.plugins.module_utils.base import sensu_argument_spec, AnsibleSensuClient
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    arguments, errors, utils,
+)
 
 
 def main():
-    argspec = sensu_argument_spec()
-    argspec.update(
-        dict(
-            name=dict(),
-        )
-    )
-
     module = AnsibleModule(
         supports_check_mode=True,
-        argument_spec=argspec,
+        argument_spec=dict(
+            arguments.COMMON_ARGUMENTS,
+            name=dict(),
+        ),
     )
 
-    client = AnsibleSensuClient(module)
-
-    if module.params['name']:
-        result = [client.get('/assets/{0}'.format(module.params['name']))]
+    client = arguments.get_sensu_client(module.params)
+    if module.params["name"]:
+        path = "/assets/{0}".format(module.params["name"])
     else:
-        result = client.get('/assets')
+        path = "/assets"
 
-    module.exit_json(changed=False, assets=result)
+    try:
+        assets = utils.get(client, path)
+    except errors.Error as e:
+        module.fail_json(msg=str(e))
+
+    if module.params["name"]:
+        assets = [assets]
+    module.exit_json(changed=False, assets=assets)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/unit/module_utils/test_arguments.py
+++ b/tests/unit/module_utils/test_arguments.py
@@ -1,0 +1,80 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    arguments,
+)
+
+
+class TestGetMutationPayload:
+    def test_no_key(self):
+        params = dict(
+            name="name",
+            namespace="space",
+        )
+
+        assert arguments.get_mutation_payload(params) == dict(
+            metadata=dict(
+                name="name",
+                namespace="space",
+            ),
+        )
+
+    def test_wanted_key(self):
+        params = dict(
+            name="name",
+            namespace="space",
+            key="value",
+        )
+
+        assert arguments.get_mutation_payload(params, "key") == dict(
+            key="value",
+            metadata=dict(
+                name="name",
+                namespace="space",
+            ),
+        )
+
+    def test_labels(self):
+        params = dict(
+            name="name",
+            namespace="space",
+            labels=dict(
+                some="label",
+                numeric=3,
+            ),
+        )
+
+        assert arguments.get_mutation_payload(params) == dict(
+            metadata=dict(
+                name="name",
+                namespace="space",
+                labels=dict(
+                    some="label",
+                    numeric="3",
+                ),
+            ),
+        )
+
+    def test_annotations(self):
+        params = dict(
+            name="name",
+            namespace="space",
+            annotations=dict(
+                my="Annotation",
+                number=45,
+            ),
+        )
+
+        assert arguments.get_mutation_payload(params) == dict(
+            metadata=dict(
+                name="name",
+                namespace="space",
+                annotations=dict(
+                    my="Annotation",
+                    number="45",
+                ),
+            ),
+        )

--- a/tests/unit/module_utils/test_client.py
+++ b/tests/unit/module_utils/test_client.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    client, errors,
+)
+
+
+class TestToken:
+    def test_get_valid_token(self, mocker):
+        open_url = mocker.patch.object(client, "open_url")
+        open_url.return_value.read.return_value = '{"access_token": "token"}'
+
+        c = client.Client("http://example.com/", "user", "pass")
+
+        assert "token" == c.token
+        assert 1 == open_url.call_count
+        print(open_url.call_args)
+        assert ("http://example.com/auth",) == open_url.call_args[0]
+        assert "user" == open_url.call_args[1]["url_username"]
+        assert "pass" == open_url.call_args[1]["url_password"]
+
+    def test_cache_token(self, mocker):
+        open_url = mocker.patch.object(client, "open_url")
+        open_url.return_value.read.return_value = '{"access_token": "token"}'
+
+        c = client.Client("http://example.com/", "user", "pass")
+        for i in range(5):
+            c.token
+
+        assert 1 == open_url.call_count
+
+    def test_login_failure(self, mocker):
+        open_url = mocker.patch.object(client, "open_url")
+        open_url.side_effect = URLError("Invalid")
+
+        with pytest.raises(errors.ClientError):
+            client.Client("http://example.com/", "user", "pass").token
+
+
+class TestRequest:
+    def test_valid_json(self, mocker):
+        auth_resp = mocker.Mock()
+        auth_resp.read.return_value = '{"access_token": "token"}'
+        data_resp = mocker.Mock()
+        data_resp.read.return_value = '{"some": "json"}'
+        data_resp.getcode.return_value = 200
+        open_url = mocker.patch.object(client, "open_url")
+        open_url.side_effect = auth_resp, data_resp
+
+        resp = client.Client("http://ex.com/", "user", "pass").request(
+            "GET", "/path",
+        )
+
+        assert 200 == resp.status
+        assert '{"some": "json"}' == resp.data
+        assert {"some": "json"} == resp.json
+
+        url = open_url.call_args[1]["url"]
+        assert "http://ex.com/api/core/v2/path" == url
+
+        auth = open_url.call_args[1]["headers"]["Authorization"]
+        assert "Bearer token" == auth
+
+    def test_invalid_json(self, mocker):
+        auth_resp = mocker.Mock()
+        auth_resp.read.return_value = '{"access_token": "token"}'
+        data_resp = mocker.Mock()
+        data_resp.read.return_value = "Bad json {}"
+        data_resp.getcode.return_value = 200
+        open_url = mocker.patch.object(client, "open_url")
+        open_url.side_effect = auth_resp, data_resp
+
+        resp = client.Client("http://ex.com/", "user", "pass").get("/path")
+
+        assert 200 == resp.status
+        assert "Bad json {}" == resp.data
+        assert resp.json is None
+
+    def test_non_200(self, mocker):
+        auth_resp = mocker.Mock()
+        auth_resp.read.return_value = '{"access_token": "token"}'
+        data_resp = HTTPError("url", 404, '{"msg": "missing item"}', {}, None)
+        open_url = mocker.patch.object(client, "open_url")
+        open_url.side_effect = auth_resp, data_resp
+
+        resp = client.Client("http://ex.com/", "user", "pass").get("/path")
+
+        assert 404 == resp.status
+        assert '{"msg": "missing item"}' == resp.data
+        assert {"msg": "missing item"} == resp.json
+
+    def test_set_json_content_type(self, mocker):
+        auth_resp = mocker.Mock()
+        auth_resp.read.return_value = '{"access_token": "token"}'
+        data_resp = mocker.Mock()
+        data_resp.read.return_value = '{"some": "json"}'
+        data_resp.getcode.return_value = 201
+        open_url = mocker.patch.object(client, "open_url")
+        open_url.side_effect = auth_resp, data_resp
+
+        resp = client.Client("http://ex.com/", "user", "pass").put("/path", {})
+
+        data = open_url.call_args[1]["data"]
+        print(data)
+        assert "{}" == data
+
+        content_type = open_url.call_args[1]["headers"]["content-type"]
+        assert "application/json" == content_type
+
+    def test_url_error(self, mocker):
+        auth_resp = mocker.Mock()
+        auth_resp.read.return_value = '{"access_token": "token"}'
+        open_url = mocker.patch.object(client, "open_url")
+        open_url.side_effect = auth_resp, URLError("Invalid")
+
+        with pytest.raises(errors.ClientError):
+            client.Client("http://ex.com/", "user", "pass").get("/path")
+
+    def test_namespace_url_construction(self, mocker):
+        auth_resp = mocker.Mock()
+        auth_resp.read.return_value = '{"access_token": "token"}'
+        data_resp = mocker.Mock()
+        data_resp.read.return_value = ""
+        data_resp.getcode.return_value = 204
+        open_url = mocker.patch.object(client, "open_url")
+        open_url.side_effect = auth_resp, data_resp
+
+        resp = client.Client(
+            "http://ex.com/", "user", "pass", "ns",
+        ).delete("/path")
+
+        url = open_url.call_args[1]["url"]
+        assert "http://ex.com/api/core/v2/namespaces/ns/path" == url
+        assert 204 == resp.status

--- a/tests/unit/module_utils/test_response.py
+++ b/tests/unit/module_utils/test_response.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import response
+
+
+class TestInit:
+    def test_with_valid_json(self):
+        resp = response.Response(201, '{"some": ["json", "data", 3]}')
+
+        assert 201 == resp.status
+        assert '{"some": ["json", "data", 3]}' == resp.data
+        assert {"some": ["json", "data", 3]} == resp.json
+
+    def test_with_invalid_json(self):
+        resp = response.Response(404, "")
+
+        assert 404 == resp.status
+        assert "" == resp.data
+        assert resp.json is None

--- a/tests/unit/module_utils/test_utils.py
+++ b/tests/unit/module_utils/test_utils.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    errors, response, utils,
+)
+
+
+class TestSync:
+    def test_absent_no_current_object(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(404, "")
+
+        changed, object = utils.sync("absent", client, "/path", {}, False)
+
+        assert changed is False
+        assert object is None
+
+    def test_absent_no_current_object_check(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(404, "")
+
+        changed, object = utils.sync("absent", client, "/path", {}, True)
+
+        assert changed is False
+        assert object is None
+
+    def test_absent_current_object_present(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(200, '{}')
+        client.delete.return_value = response.Response(204, "")
+
+        changed, object = utils.sync("absent", client, "/path", {}, False)
+
+        assert changed is True
+        assert object is None
+        client.delete.assert_called_with("/path")
+
+    def test_absent_current_object_present_check(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(200, '{}')
+        client.delete.return_value = response.Response(204, "")
+
+        changed, object = utils.sync("absent", client, "/path", {}, True)
+
+        assert changed is True
+        assert object is None
+        client.delete.assert_not_called()
+
+    def test_present_no_current_object(self, mocker):
+        client = mocker.Mock()
+        client.get.side_effect = (
+            response.Response(404, ""),
+            response.Response(200, '{"new": "data"}'),
+        )
+        client.put.return_value = response.Response(201, "")
+
+        changed, object = utils.sync(
+            "present", client, "/path", {"my": "data"}, False,
+        )
+
+        assert changed is True
+        assert {"new": "data"} == object
+        client.put.assert_called_once_with("/path", {"my": "data"})
+
+    def test_present_no_current_object_check(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(404, "")
+
+        changed, object = utils.sync(
+            "present", client, "/path", {"my": "data"}, True,
+        )
+
+        assert changed is True
+        assert {"my": "data"} == object
+        client.put.assert_not_called()
+
+    def test_present_current_object_differ(self, mocker):
+        client = mocker.Mock()
+        client.get.side_effect = (
+            response.Response(200, '{"current": "data"}'),
+            response.Response(200, '{"new": "data"}'),
+        )
+        client.put.return_value = response.Response(201, "")
+
+        changed, object = utils.sync(
+            "present", client, "/path", {"my": "data"}, False,
+        )
+
+        assert changed is True
+        assert {"new": "data"} == object
+        client.put.assert_called_once_with("/path", {"my": "data"})
+
+    def test_present_current_object_differ_check(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(200, '{"current": "data"}')
+
+        changed, object = utils.sync(
+            "present", client, "/path", {"my": "data"}, True,
+        )
+
+        assert changed is True
+        assert {"my": "data"} == object
+        client.put.assert_not_called()
+
+    def test_present_current_object_does_not_differ(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(200, '{"my": "data"}')
+
+        changed, object = utils.sync(
+            "present", client, "/path", {"my": "data"}, False,
+        )
+
+        assert changed is False
+        assert {"my": "data"} == object
+        client.put.assert_not_called()
+
+    def test_present_current_object_does_not_differ_check(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(200, '{"my": "data"}')
+
+        changed, object = utils.sync(
+            "present", client, "/path", {"my": "data"}, True,
+        )
+
+        assert changed is False
+        assert {"my": "data"} == object
+        client.put.assert_not_called()
+
+
+class TestDoDiffer:
+    @pytest.mark.parametrize("desired", [None, {"a": "b"}, 1, False, 2.3])
+    def test_current_none_always_differ(self, desired):
+        assert utils.do_differ(None, desired) is True
+
+    def test_extra_keys_in_current_do_not_matter(self):
+        assert utils.do_differ({"a": "b", "c": 3}, {"a": "b"}) is False
+
+    def test_detect_different_values(self):
+        assert utils.do_differ({"a": "b"}, {"a": "c"}) is True
+
+    def test_detect_missing_keys_in_current(self):
+        assert utils.do_differ({"a": "b"}, {"c": "d"}) is True
+
+    def test_desired_none_values_are_ignored(self):
+        assert utils.do_differ({"a": "b"}, {"c": None}) is False
+
+
+class TestGet:
+    @pytest.mark.parametrize(
+        "status", [100, 201, 202, 203, 204, 400, 401, 403, 500, 501],
+    )
+    def test_abort_on_invalid_status(self, mocker, status):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(status, "")
+
+        with pytest.raises(errors.SyncError, match=str(status)):
+            utils.get(client, "/get")
+        client.get.assert_called_once_with("/get")
+
+    def test_abort_on_invalid_json(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(200, "")
+
+        with pytest.raises(errors.SyncError, match="JSON"):
+            utils.get(client, "/get")
+        client.get.assert_called_once_with("/get")
+
+    def test_ignore_invalid_json_on_404(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(404, "")
+
+        object = utils.get(client, "/get")
+
+        assert object is None
+        client.get.assert_called_once_with("/get")
+
+    def test_valid_json(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = response.Response(200, '{"get": "data"}')
+
+        object = utils.get(client, "/get")
+
+        assert {"get": "data"} == object
+        client.get.assert_called_once_with("/get")
+
+
+class TestDelete:
+    @pytest.mark.parametrize(
+        "status", [100, 200, 201, 202, 203, 400, 401, 403, 500, 501],
+    )
+    def test_abort_on_invalid_status(self, mocker, status):
+        client = mocker.Mock()
+        client.delete.return_value = response.Response(status, "")
+
+        with pytest.raises(errors.SyncError, match=str(status)):
+            utils.delete(client, "/delete")
+        client.delete.assert_called_once_with("/delete")
+
+    def test_valid_delete(self, mocker):
+        client = mocker.Mock()
+        client.delete.return_value = response.Response(204, "{}")
+
+        object = utils.delete(client, "/delete")
+
+        assert object is None
+        client.delete.assert_called_once_with("/delete")
+
+
+class TestPut:
+    @pytest.mark.parametrize(
+        "status", [100, 200, 202, 203, 204, 400, 401, 403, 500, 501],
+    )
+    def test_abort_on_invalid_status(self, mocker, status):
+        client = mocker.Mock()
+        client.put.return_value = response.Response(status, "")
+
+        with pytest.raises(errors.SyncError, match=str(status)):
+            utils.put(client, "/put", {"payload": "data"})
+        client.put.assert_called_once_with("/put", {"payload": "data"})
+
+    def test_valid_put(self, mocker):
+        client = mocker.Mock()
+        client.put.return_value = response.Response(201, '{"put": "data"}')
+
+        object = utils.put(client, "/put", {"payload": "data"})
+
+        assert object is None
+        client.put.assert_called_once_with("/put", {"payload": "data"})
+
+
+class TestDictToSingleItemDicts:
+    def test_conversion(self):
+        result = utils.dict_to_single_item_dicts({"a": 0, 1: "b"})
+
+        assert 2 == len(result)
+        for item in ({"a": 0}, {1: "b"}):
+            assert item in result
+
+
+class TestDictToKeyValueString:
+    def test_conversion(self):
+        result = utils.dict_to_key_value_strings({"a": 0, 1: "b"})
+
+        assert {"a=0", "1=b"} == set(result)

--- a/tests/unit/modules/common/sensu_go_object.py
+++ b/tests/unit/modules/common/sensu_go_object.py
@@ -34,7 +34,9 @@ class TestSensuGoObjectBase(object):
         with patch('ansible_collections.sensu.sensu_go.plugins.module_utils.base.open_url') as open_url_mock:
             self._configure_mock(open_url_mock, test_case)
             # _ansible_* keys are added here, we deepcopy it so it doesn't mess with our test case
-            set_module_args(self._prepare_input_params(copy.deepcopy(test_case)))
+            set_module_args(
+                **self._prepare_input_params(copy.deepcopy(test_case))
+            )
 
             with pytest.raises(self._get_exit_class(test_case)) as context:
                 self.module.main()

--- a/tests/unit/modules/common/sensu_go_object_info.py
+++ b/tests/unit/modules/common/sensu_go_object_info.py
@@ -25,7 +25,9 @@ class TestSensuGoObjectInfoBase(object):
         with patch('ansible_collections.sensu.sensu_go.plugins.module_utils.base.open_url') as open_url_mock:
             self._configure_mock(open_url_mock, test_case)
             # _ansible_* keys are added here, we deepcopy it so it doesn't mess with our test case
-            set_module_args(self._prepare_input_params(copy.deepcopy(test_case)))
+            set_module_args(
+                **self._prepare_input_params(copy.deepcopy(test_case))
+            )
 
             with pytest.raises(AnsibleExitJson) as context:
                 self.module.main()

--- a/tests/unit/modules/common/utils.py
+++ b/tests/unit/modules/common/utils.py
@@ -12,7 +12,7 @@ except ImportError:
     from mock import patch  # Python 2 needs mock package installed
 
 
-def set_module_args(args):
+def set_module_args(**args):
     if '_ansible_remote_tmp' not in args:
         args['_ansible_remote_tmp'] = '/tmp'
     if '_ansible_keep_remote_files' not in args:
@@ -43,10 +43,10 @@ def fail_json(*args, **kwargs):
 
 class ModuleTestCase:
     def setup_method(self):
-        self.mock_module = patch.multiple(basic.AnsibleModule, exit_json=exit_json,
-                                          fail_json=fail_json)
+        self.mock_module = patch.multiple(
+            basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json,
+        )
         self.mock_module.start()
-        set_module_args({})
 
     def teardown_method(self):
         self.mock_module.stop()


### PR DESCRIPTION
Original code that we inherited is only modular on the surface. Its various components share so much state between them that it is almost impossible to validate the correctness of each element separately.

Changes in this pull request split the functionality into three separate layers:

 1. the HTTP layer that we can use to interact with the Sensu's web API (`Response` and `Client` classes),
 2. the utility layer that contains various utility functions that help us synchronize the playbook and Sensu server states (`utils` module), and
 3. modules that are responsible for splitting transforming the task parameters into payload for the synchronization functions.

This separation of concerns allows us to write robust tests for each component without risking an exponential explosion of test scenarios that need to be covered.

Note that we did not remove any old code yet since at the moment, only asset module uses newly refactored common functionality. Other modules can be migrated gradually and when we have no legacy module left, old code can be purged from the repository.