### PR TITLE
The sensu.sensu_go.install role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ workflows:
       - unit_python36_ansible29
       - unit_python37_ansible29
 
-      - integration_ansible29_git
+      - modules_integration_ansible29_git
+      - install_role_integration_ansible29_git
 
   daily_master:
     triggers:
@@ -19,7 +20,8 @@ workflows:
           cron: "12 4 * * *"
           filters: { branches: { only: [ master ] } }
     jobs:
-      - integration_ansible29_git
+      - modules_integration_ansible29_git
+      - install_role_integration_ansible29_git
 
   daily_released:
     triggers:
@@ -27,7 +29,8 @@ workflows:
           cron: "12 5 * * *"
           filters: { branches: { only: [ stable ] } }
     jobs:
-      - integration_ansible29_galaxy
+      - modules_integration_ansible29_galaxy
+      - install_role_integration_ansible29_galaxy
 
 # A list of all supported python versions.
 executors:
@@ -98,16 +101,32 @@ jobs:
 
   # Integration tests run on single python version, because python portability
   # is checked by sanity and unit tests.
-  integration_ansible29_git:
+  modules_integration_ansible29_git:
     executor: python37
     environment:
       ANSIBLE_VERSION: ==2.9.0b1
+      INTEGRATION_TEST_SECTION: modules
     steps: [ integration_test_git ]
 
-  integration_ansible29_galaxy:
+  install_role_integration_ansible29_git:
     executor: python37
     environment:
       ANSIBLE_VERSION: ==2.9.0b1
+      INTEGRATION_TEST_SECTION: roles/install
+    steps: [ integration_test_git ]
+
+  modules_integration_ansible29_galaxy:
+    executor: python37
+    environment:
+      ANSIBLE_VERSION: ==2.9.0b1
+      INTEGRATION_TEST_SECTION: modules
+    steps: [ integration_test_galaxy ]
+
+  install_role_integration_ansible29_galaxy:
+    executor: python37
+    environment:
+      ANSIBLE_VERSION: ==2.9.0b1
+      INTEGRATION_TEST_SECTION: role/installs
     steps: [ integration_test_galaxy ]
 
 commands:
@@ -207,7 +226,7 @@ commands:
       - run:
           name: Run integration tests
           command: |
-            cd tests/integration/modules
+            cd tests/integration/${INTEGRATION_TEST_SECTION}
             molecule --base-config molecule/shared/base.yml test --all
 
   report_coverage:

--- a/roles/install/README.md
+++ b/roles/install/README.md
@@ -1,0 +1,93 @@
+Role sensu.sensu_go.install
+=========
+
+Install Sensu Go commands (`sensuctl`, `sensu-backend`, `sensu-agent`) from official
+precompiled packages.
+
+NOTE: This role only configures your package manager (like yum or apt) and installs
+the binaries. It does **not** configure anything and it does **not** run any services.
+
+
+Requirements
+------------
+
+This role has no requirements.
+
+Role Variables
+--------------
+
+This role expects you to provide only a single variable, `components: []`, which is a list
+of one or more Sensu Go components that you want to have installed in your inventory.
+By default, all three components will be installed:
+
+```yaml
+components:
+  - sensu-go-backend
+  - sensu-go-agent
+  - sensu-go-cli
+```
+
+You can specify exact version per component like this:
+
+```yaml
+components:
+  - name: sensu-go-backend
+    version: 5.12.0
+  - name: sensu-go-cli
+    version: 5.12.0
+```
+
+Supported Tags
+---------
+
+| Tag               | Effect                                                   |
+|-------------------|----------------------------------------------------------|
+| configure_install | Skip this tag to skip the package manager configuration; just install components |
+| install           | Skip this tag to skip all tasks of the role; useful when role is required by other role but you don't want it to run 
+
+Dependencies
+------------
+
+This role has not dependencies on other roles.
+
+Example Playbook
+----------------
+
+```yaml
+- name: Install sensu-backend and sensuctl binaries
+  hosts: backends
+  collections: [sensu.sensu_go]
+  roles:
+     - {role: install, components: [sensu-go-backend, sensu-go-cli]}
+
+- name: Install sensu-agent binary
+  hosts: agents
+  collections: [sensu.sensu_go]
+  roles:
+     - {role: install, components: [sensu-go-agent]}
+
+- name: Install sensuctl at specific version
+  hosts: all
+  collections: [sensu.sensu_go]
+  roles:
+     - role: install
+       components:
+          - {name: sensu-go-cli, version: '5.12.0'}
+```
+
+Tested Platforms (CI/CD)
+------------------------
+| OS       | Distributions                     |
+|----------|-----------------------------------|
+| Centos   | 6, 7                              |
+| Ubuntu   | 14.04, 16.04, 18.04, 18.10, 19.04 |
+
+License
+-------
+
+GPL3
+
+Author Information
+------------------
+
+steampunk@xlab.si

--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+os: unknown
+dist: unknown
+
+components:
+  - sensu-go-backend
+  - sensu-go-agent
+  - sensu-go-cli

--- a/roles/install/tasks/apt/install.yml
+++ b/roles/install/tasks/apt/install.yml
@@ -1,0 +1,4 @@
+---
+- name: Install components
+  include_tasks: install_one.yml
+  loop: '{{ _components }}'

--- a/roles/install/tasks/apt/install_one.yml
+++ b/roles/install/tasks/apt/install_one.yml
@@ -1,0 +1,17 @@
+---
+- name: Latest component version
+  set_fact:
+    pkg_name: '{{ item.name }}'
+    pkg_state: latest
+  when: item.version == 'latest'
+
+- name: Specific component version ({{ item.version }})
+  set_fact:
+    pkg_name: '{{ item.name }}={{ item.version }}-*'
+    pkg_state: present
+  when: item.version != 'latest'
+
+- name: Install component ({{ pkg_name }})
+  apt:
+    name: '{{ pkg_name }}'
+    state: '{{ pkg_state }}'

--- a/roles/install/tasks/apt/prepare.yml
+++ b/roles/install/tasks/apt/prepare.yml
@@ -1,0 +1,28 @@
+---
+- name: Include distro-specific vars ({{ ansible_distribution }})
+  include_vars: file='{{ ansible_distribution }}.yml'
+
+- name: Install utility packages
+  apt:
+    name:
+      - gnupg
+      - debian-archive-keyring
+      - apt-transport-https
+    state: present
+
+- name: Add apt key
+  apt_key:
+    url: https://packagecloud.io/sensu/stable/gpgkey
+    id: 0A3F7426
+
+- name: Add apt repository
+  apt_repository:
+    repo: deb https://packagecloud.io/sensu/stable/{{ os }}/ {{ dist }} main
+    filename: /etc/apt/sources.list.d/sensu_stable.list
+    validate_certs: yes
+
+- name: Add apt source repository
+  apt_repository:
+    repo: deb-src https://packagecloud.io/sensu/stable/{{ os }}/ {{ dist }} main
+    filename: /etc/apt/sources.list.d/sensu_stable.list
+    validate_certs: yes

--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Prepare package manager ({{ ansible_pkg_mgr }})
+  include_tasks: '{{ ansible_pkg_mgr }}/prepare.yml'
+  tags:
+    - prepare_install
+    - install
+
+# Each component can be either simple string (package name) or
+# a dict {name: NAME, version: VERSION}. Here we unify this.
+- name: Normalize components list
+  set_fact:
+    _components: |
+      {{ _components | default([]) + [{'name': item.name|default(item),
+      'version': item.version|default('latest')}] }}
+  loop: '{{ components }}'
+  tags:
+    - install
+
+- name: Install components
+  include_tasks: '{{ ansible_pkg_mgr }}/install.yml'
+  tags:
+    - install

--- a/roles/install/tasks/yum/install.yml
+++ b/roles/install/tasks/yum/install.yml
@@ -1,0 +1,4 @@
+---
+- name: Install components
+  include_tasks: install_one.yml
+  loop: '{{ _components }}'

--- a/roles/install/tasks/yum/install_one.yml
+++ b/roles/install/tasks/yum/install_one.yml
@@ -1,0 +1,18 @@
+---
+- name: Latest component version
+  set_fact:
+    pkg_name: '{{ item.name }}'
+    pkg_state: latest
+  when: item.version == 'latest'
+
+- name: Specific component version ({{ item.version }})
+  set_fact:
+    pkg_name: '{{ item.name }}-{{ item.version }}'
+    pkg_state: present
+  when: item.version != 'latest'
+
+- name: Install component ({{ pkg_name }})
+  yum:
+    name: '{{ pkg_name }}'
+    state: '{{ pkg_state }}'
+    allow_downgrade: '{{ item.version != "latest" }}'

--- a/roles/install/tasks/yum/prepare.yml
+++ b/roles/install/tasks/yum/prepare.yml
@@ -1,0 +1,31 @@
+---
+- name: Include distro-specific vars ({{ ansible_distribution }})
+  include_vars: file='{{ ansible_distribution }}.yml'
+
+- name: Add yum repository
+  yum_repository:
+    name: sensu_stable
+    description: sensu_stable
+    file: sensu
+    baseurl: https://packagecloud.io/sensu/stable/{{ os }}/{{ dist }}/$basearch
+    gpgkey: https://packagecloud.io/sensu/stable/gpgkey
+    gpgcheck: no
+    repo_gpgcheck: yes
+    enabled: yes
+    sslverify: yes
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    metadata_expire: '300'
+
+- name: Add yum source repository
+  yum_repository:
+    name: sensu_stable-source
+    description: sensu_stable-source
+    file: sensu
+    baseurl: https://packagecloud.io/sensu/stable/{{ os }}/{{ dist }}/SRPMS
+    gpgkey: https://packagecloud.io/sensu/stable/gpgkey
+    gpgcheck: no
+    repo_gpgcheck: yes
+    enabled: yes
+    sslverify: yes
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    metadata_expire: '300'

--- a/roles/install/vars/CentOS.yml
+++ b/roles/install/vars/CentOS.yml
@@ -1,0 +1,3 @@
+---
+os: el
+dist: '{{ ansible_distribution_version.split(".")[0] }}'

--- a/roles/install/vars/Ubuntu.yml
+++ b/roles/install/vars/Ubuntu.yml
@@ -1,0 +1,3 @@
+---
+os: ubuntu
+dist: '{{ ansible_distribution_release }}'

--- a/tests/integration/roles/install/molecule/centos/Dockerfile.j2
+++ b/tests/integration/roles/install/molecule/centos/Dockerfile.j2
@@ -1,0 +1,1 @@
+../shared/Dockerfile.j2

--- a/tests/integration/roles/install/molecule/centos/molecule.yml
+++ b/tests/integration/roles/install/molecule/centos/molecule.yml
@@ -1,0 +1,33 @@
+---
+scenario:
+  name: centos
+platforms:
+  #
+  # Install latest version of components
+  #
+  - name: centos-6
+    image: centos:6
+    groups: [latest_components]
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+  - name: centos-7
+    image: centos:7
+    groups: [latest_components]
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+  #
+  # Install older version of components
+  #
+  - name: 2nd-centos-7
+    image: centos:7
+    groups: [older_components]
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/tests/integration/roles/install/molecule/centos/playbook.yml
+++ b/tests/integration/roles/install/molecule/centos/playbook.yml
@@ -1,0 +1,1 @@
+../shared/playbook.yml

--- a/tests/integration/roles/install/molecule/centos/tests/test_centos.py
+++ b/tests/integration/roles/install/molecule/centos/tests/test_centos.py
@@ -1,0 +1,1 @@
+# Keep this file or shared tests won't be run.

--- a/tests/integration/roles/install/molecule/shared/Dockerfile.j2
+++ b/tests/integration/roles/install/molecule/shared/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/tests/integration/roles/install/molecule/shared/base.yml
+++ b/tests/integration/roles/install/molecule/shared/base.yml
@@ -1,0 +1,62 @@
+---
+scenario:
+  test_sequence:
+    - lint
+    - cleanup
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - side_effect
+    - verify
+    - cleanup
+    - destroy
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-data:
+      rules:
+        braces:
+          max-spaces-inside: 1
+          level: error
+        brackets:
+          max-spaces-inside: 1
+          level: error
+        colons:
+          max-spaces-after: -1
+          level: error
+        commas:
+          max-spaces-after: -1
+          level: error
+        comments: disable
+        comments-indentation: disable
+        document-start: disable
+        empty-lines:
+          max: 3
+          level: error
+        hyphens:
+          level: error
+        indentation: disable
+        key-duplicates: enable
+        line-length: disable
+        new-line-at-end-of-file: disable
+        new-lines:
+          type: unix
+        trailing-spaces: disable
+        truthy: disable
+provisioner:
+  name: ansible
+  lint:
+    enabled: false
+verifier:
+  name: testinfra
+  additional_files_or_dirs:
+    - ../../shared/tests/test_*
+  lint:
+    name: flake8

--- a/tests/integration/roles/install/molecule/shared/playbook.yml
+++ b/tests/integration/roles/install/molecule/shared/playbook.yml
@@ -1,0 +1,27 @@
+---
+- name: Converge with latest versions of components
+  hosts: latest_components
+  collections:
+    - sensu.sensu_go
+  vars:
+    components:
+      - sensu-go-backend
+      - sensu-go-agent
+      - sensu-go-cli
+  roles:
+    - install
+
+- name: Converge with older versions of components
+  hosts: older_components
+  collections:
+    - sensu.sensu_go
+  vars:
+    components:
+      - name: sensu-go-backend
+        version: 5.12.0
+      - name: sensu-go-agent
+        version: 5.12.0
+      - name: sensu-go-cli
+        version: 5.12.0
+  roles:
+    - install

--- a/tests/integration/roles/install/molecule/shared/tests/test_latest_installed.py
+++ b/tests/integration/roles/install/molecule/shared/tests/test_latest_installed.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import requests
+
+
+def latest_sensu_available():
+    """Access webpage to learn what the latest Sensu version is"""
+    res = requests.get("https://docs.sensu.io/sensu-go/latest", allow_redirects=False)
+    latest_url = res.headers.get("Location", "unknown").strip("/")
+    return latest_url.split("/")[-1]
+
+
+testinfra_hosts = ["latest_components"]
+LATEST_VERSION = latest_sensu_available()
+
+
+def test_backend_installed(host):
+    assert host.exists("sensu-backend")
+    assert "sensu-backend version {0}".format(LATEST_VERSION) in \
+           host.check_output("sensu-backend version")
+
+
+def test_agent_installed(host):
+    assert host.exists("sensu-agent")
+    assert "sensu-agent version {0}".format(LATEST_VERSION) in \
+           host.check_output("sensu-agent version")
+
+
+def test_cli_installed(host):
+    assert host.exists("sensuctl")
+    assert "sensuctl version {0}".format(LATEST_VERSION) in \
+           host.check_output("sensuctl version")

--- a/tests/integration/roles/install/molecule/shared/tests/test_older_installed.py
+++ b/tests/integration/roles/install/molecule/shared/tests/test_older_installed.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+testinfra_hosts = ["older_components"]
+OLDER_VERSION = "5.12.0"
+
+
+def test_backend_installed(host):
+    assert host.exists("sensu-backend")
+    assert "sensu-backend version {0}".format(OLDER_VERSION) in \
+           host.check_output("sensu-backend version")
+
+
+def test_agent_installed(host):
+    assert host.exists("sensu-agent")
+    assert "sensu-agent version {0}".format(OLDER_VERSION) in \
+           host.check_output("sensu-agent version")
+
+
+def test_cli_installed(host):
+    assert host.exists("sensuctl")
+    assert "sensuctl version {0}".format(OLDER_VERSION) in \
+           host.check_output("sensuctl version")

--- a/tests/integration/roles/install/molecule/ubuntu/Dockerfile.j2
+++ b/tests/integration/roles/install/molecule/ubuntu/Dockerfile.j2
@@ -1,0 +1,1 @@
+../shared/Dockerfile.j2

--- a/tests/integration/roles/install/molecule/ubuntu/molecule.yml
+++ b/tests/integration/roles/install/molecule/ubuntu/molecule.yml
@@ -1,0 +1,63 @@
+---
+scenario:
+  name: ubuntu
+platforms:
+  #
+  # Install latest version of components
+  #
+  - name: ubuntu-14.04
+    image: ubuntu:14.04
+    pull: yes
+    groups: [latest_components]
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+  - name: ubuntu-16.04
+    image: ubuntu:16.04
+    pull: yes
+    groups: [latest_components]
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+  - name: ubuntu-18.04
+    image: ubuntu:18.04
+    pull: yes
+    groups: [latest_components]
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+  - name: ubuntu-18.10
+    image: ubuntu:18.10
+    pull: yes
+    groups: [latest_components]
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+  - name: ubuntu-19.04
+    image: ubuntu:19.04
+    pull: yes
+    groups: [latest_components]
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+  #
+  # Install older version of components
+  #
+  - name: 2nd-ubuntu-16.04
+    image: ubuntu:16.04
+    pull: yes
+    groups: [older_components]
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/tests/integration/roles/install/molecule/ubuntu/playbook.yml
+++ b/tests/integration/roles/install/molecule/ubuntu/playbook.yml
@@ -1,0 +1,1 @@
+../shared/playbook.yml

--- a/tests/integration/roles/install/molecule/ubuntu/tests/test_ubuntu.py
+++ b/tests/integration/roles/install/molecule/ubuntu/tests/test_ubuntu.py
@@ -1,0 +1,1 @@
+# Keep this file or shared tests won't be run.


### PR DESCRIPTION
With this commit we introduce a role that configures target's package manager and then installs desired Sensu Go binary with it. Following binaries are currently present:

- sensu-go-backend
- sensu-go-agent
- sensu-go-cli

Currently the role supports following target platforms:

- Centos 6 & 7
- Ubuntu 14.04 & 16.04 & 18.04 & 18.10 & 19.04

Role allows you to either install latest version of the component or specify specific version, but that version must exist in the stable package repository.