### PR TITLE
[WIP]: Move platforms into base molecule config

### DIFF
--- a/integration.requirements
+++ b/integration.requirements
@@ -1,2 +1,2 @@
-molecule[docker]
+molecule[docker] == 3.0a4  # Exact version because this is prerelease
 selinux

--- a/tests/integration/modules/molecule/asset/molecule.yml
+++ b/tests/integration/modules/molecule/asset/molecule.yml
@@ -1,22 +1,3 @@
 ---
 scenario:
   name: asset
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug

--- a/tests/integration/modules/molecule/check/molecule.yml
+++ b/tests/integration/modules/molecule/check/molecule.yml
@@ -1,22 +1,3 @@
 ---
 scenario:
   name: check
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug

--- a/tests/integration/modules/molecule/entity/molecule.yml
+++ b/tests/integration/modules/molecule/entity/molecule.yml
@@ -1,16 +1,3 @@
 ---
 scenario:
   name: entity
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: &cmd >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: *cmd
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: *cmd

--- a/tests/integration/modules/molecule/filter/molecule.yml
+++ b/tests/integration/modules/molecule/filter/molecule.yml
@@ -1,22 +1,3 @@
 ---
 scenario:
   name: filter
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug

--- a/tests/integration/modules/molecule/handler_set/molecule.yml
+++ b/tests/integration/modules/molecule/handler_set/molecule.yml
@@ -1,22 +1,3 @@
 ---
 scenario:
   name: handler_set
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug

--- a/tests/integration/modules/molecule/hook/molecule.yml
+++ b/tests/integration/modules/molecule/hook/molecule.yml
@@ -1,16 +1,3 @@
 ---
 scenario:
   name: hook
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: &cmd >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: *cmd
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: *cmd

--- a/tests/integration/modules/molecule/mutator/molecule.yml
+++ b/tests/integration/modules/molecule/mutator/molecule.yml
@@ -1,16 +1,3 @@
 ---
 scenario:
   name: mutator
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: &cmd >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: *cmd
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: *cmd

--- a/tests/integration/modules/molecule/namespace/molecule.yml
+++ b/tests/integration/modules/molecule/namespace/molecule.yml
@@ -1,16 +1,3 @@
 ---
 scenario:
   name: namespace
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: &cmd >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: *cmd
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: *cmd

--- a/tests/integration/modules/molecule/pipe_handler/molecule.yml
+++ b/tests/integration/modules/molecule/pipe_handler/molecule.yml
@@ -1,22 +1,3 @@
 ---
 scenario:
   name: pipe_handler
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug

--- a/tests/integration/modules/molecule/role/molecule.yml
+++ b/tests/integration/modules/molecule/role/molecule.yml
@@ -1,16 +1,3 @@
 ---
 scenario:
   name: role
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: &cmd >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: *cmd
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: *cmd

--- a/tests/integration/modules/molecule/shared/base.yml
+++ b/tests/integration/modules/molecule/shared/base.yml
@@ -1,4 +1,17 @@
 ---
+platforms:
+  - name: latest
+    image: sensu/sensu:latest
+    command: &cmd >
+      sensu-backend start
+        --state-dir /var/lib/sensu/sensu-backend/etcd1
+        --log-level debug
+  - name: v5.13.1
+    image: sensu/sensu:5.13.1
+    command: *cmd
+  - name: v5.12.0
+    image: sensu/sensu:5.12.0
+    command: *cmd
 scenario:
   test_sequence:
     - lint

--- a/tests/integration/modules/molecule/silence/molecule.yml
+++ b/tests/integration/modules/molecule/silence/molecule.yml
@@ -1,16 +1,3 @@
 ---
 scenario:
   name: silence
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: &cmd >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: *cmd
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: *cmd

--- a/tests/integration/modules/molecule/socket_handler/molecule.yml
+++ b/tests/integration/modules/molecule/socket_handler/molecule.yml
@@ -1,22 +1,3 @@
 ---
 scenario:
   name: socket_handler
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug

--- a/tests/integration/modules/molecule/user/molecule.yml
+++ b/tests/integration/modules/molecule/user/molecule.yml
@@ -1,16 +1,3 @@
 ---
 scenario:
   name: user
-platforms:
-  - name: latest
-    image: sensu/sensu:latest
-    command: &cmd >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
-  - name: v5.13.1
-    image: sensu/sensu:5.13.1
-    command: *cmd
-  - name: v5.12.0
-    image: sensu/sensu:5.12.0
-    command: *cmd


### PR DESCRIPTION
NOTE: This currently does not work because molecule is not passing the complete config to the create and destroy playbooks.