### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: sensu
 name: sensu_go
-version: 0.3.0
+version: 0.7.0
 
 authors:
   - Paul Arthur <paul.arthur@flowerysong.com> (@flowerysong)


### PR DESCRIPTION
The version bump is a bit larger than one would expect because we broke the end-user API.