### PR TITLE
Add socket handler module

### DIFF
--- a/plugins/modules/socket_handler.py
+++ b/plugins/modules/socket_handler.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'XLAB Steampunk'}
+
+DOCUMENTATION = '''
+module: socket_handler
+author:
+  - Aljaz Kosir (@aljazkosir)
+  - Miha Plesko (@miha-plesko)
+  - Tadej Borovsak (@tadeboro)
+short_description: Manages Sensu TCP/UDP handler
+description:
+  - For more information, refer to the Sensu documentation at
+    U(https://docs.sensu.io/sensu-go/latest/reference/handlers/)
+extends_documentation_fragment:
+  - sensu.sensu_go.base
+  - sensu.sensu_go.object
+options:
+  type:
+    description:
+      - The handler type.
+    choices:
+      - tcp
+      - udp
+    type: str
+    required: true
+  filters:
+    description:
+      - List of filters to use when determining whether to pass the check result to this handler.
+    type: list
+  mutator:
+    description:
+      - Mutator to call for transforming the check result before passing it to this handler.
+    type: str
+  timeout:
+    description:
+      - Timeout for handler execution
+    type: int
+  host:
+    description:
+      - The socket host address (IP or hostname) to connect to.
+    required: true
+    type: str
+  port:
+    description:
+      - The socket port to connect to.
+    type: int
+    required: true
+'''
+
+EXAMPLES = '''
+- name: TCP handler
+  socket_handler:
+    name: tcp_handler
+    type: tcp
+    host: 10.0.1.99
+    port: 4444
+
+- name: UDP handler
+  socket_handler:
+    name: udp_handler
+    type: udp
+    host: 10.0.1.99
+    port: 4444
+'''
+
+RETURN = '''
+object:
+    description: object representing Sensu socket handler
+    returned: success
+    type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    arguments, errors, utils,
+)
+
+
+def main():
+    required_if = [
+        ('state', 'present', ['type', 'host', 'port'])
+    ]
+    module = AnsibleModule(
+        supports_check_mode=True,
+        required_if=required_if,
+        argument_spec=dict(
+            arguments.MUTATION_ARGUMENTS,
+            type=dict(choices=['tcp', 'udp']),
+            filters=dict(
+                type='list',
+            ),
+            mutator=dict(),
+            timeout=dict(
+                type='int'
+            ),
+            host=dict(),
+            port=dict(
+                type='int'
+            )
+        ),
+    )
+
+    client = arguments.get_sensu_client(module.params['auth'])
+    path = '/handlers/{0}'.format(module.params['name'])
+    payload = arguments.get_mutation_payload(
+        module.params, 'type', 'filters', 'mutator', 'timeout'
+    )
+    payload['socket'] = dict(host=module.params['host'], port=module.params['port'])
+
+    try:
+        changed, handler = utils.sync(
+            module.params['state'], client, path, payload, module.check_mode,
+        )
+        module.exit_json(changed=changed, object=handler)
+    except errors.Error as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/modules/molecule/socket_handler/Dockerfile.j2
+++ b/tests/integration/modules/molecule/socket_handler/Dockerfile.j2
@@ -1,0 +1,1 @@
+../shared/Dockerfile.j2

--- a/tests/integration/modules/molecule/socket_handler/molecule.yml
+++ b/tests/integration/modules/molecule/socket_handler/molecule.yml
@@ -1,0 +1,22 @@
+---
+scenario:
+  name: socket_handler
+platforms:
+  - name: latest
+    image: sensu/sensu:latest
+    command: >
+      sensu-backend start
+        --state-dir /var/lib/sensu/sensu-backend/etcd1
+        --log-level debug
+  - name: v5.13.1
+    image: sensu/sensu:5.13.1
+    command: >
+      sensu-backend start
+        --state-dir /var/lib/sensu/sensu-backend/etcd1
+        --log-level debug
+  - name: v5.12.0
+    image: sensu/sensu:5.12.0
+    command: >
+      sensu-backend start
+        --state-dir /var/lib/sensu/sensu-backend/etcd1
+        --log-level debug

--- a/tests/integration/modules/molecule/socket_handler/playbook.yml
+++ b/tests/integration/modules/molecule/socket_handler/playbook.yml
@@ -1,0 +1,153 @@
+---
+- name: Converge
+  collections:
+    - sensu.sensu_go
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Create socket handler with missing required parameters
+      socket_handler:
+        auth:
+          url: http://localhost:8080
+        name: handler
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "result.msg == 'state is present but all of the following are missing: type, host, port'"
+
+    - name: Create socket handler with minimal parameters
+      socket_handler:
+        auth:
+          url: http://localhost:8080
+        name: minimal_handler
+        type: tcp
+        host: 10.1.0.99
+        port: 4444
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.socket.host == '10.1.0.99'
+          - result.object.socket.port == 4444
+          - result.object.type == 'tcp'
+          - result.object.metadata.name == 'minimal_handler'
+
+    - name: Create socket handler with minimal parameters idempotence
+      socket_handler:
+        auth:
+          url: http://localhost:8080
+        name: minimal_handler
+        type: tcp
+        host: 10.1.0.99
+        port: 4444
+      register: result
+
+    - assert:
+        that: result is not changed
+
+    - name: Create an socket handler with full parameters
+      socket_handler:
+        auth:
+          url: http://localhost:8080
+        name: handler
+        type: udp
+        mutator: mutate_input
+        timeout: 30
+        filters:
+          - occurances
+          - production
+        host: 10.1.0.99
+        port: 4444
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.socket.host == '10.1.0.99'
+          - result.object.socket.port == 4444
+          - result.object.type == 'udp'
+          - result.object.mutator == 'mutate_input'
+          - result.object.timeout == 30
+          - result.object.filters == ['occurances', 'production']
+
+    - name: Create socket handler with full parameters idempotence
+      socket_handler:
+        auth:
+          url: http://localhost:8080
+        name: handler
+        type: udp
+        mutator: mutate_input
+        timeout: 30
+        filters:
+          - occurances
+          - production
+        host: 10.1.0.99
+        port: 4444
+      register: result
+
+    - assert:
+        that: result is not changed
+
+    - name: Modify socket handler
+      socket_handler:
+        auth:
+          url: http://localhost:8080
+        name: handler
+        type: tcp
+        timeout: 60
+        host: 10.1.0.99
+        port: 4444
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.type == 'tcp'
+          - result.object.socket.host == '10.1.0.99'
+          - result.object.socket.port == 4444
+          - not result.object.filters
+          - "'mutator' not in result.object"
+
+    - name: Fetch all socket handlers
+      handler_info:
+        auth:
+          url: http://localhost:8080
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 2
+
+    - name: Fetch a specific socket handler
+      handler_info:
+        auth:
+          url: http://localhost:8080
+        name: handler
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 1
+          - result.objects.0.metadata.name == 'handler'
+
+    - name: Delete socket handler
+      socket_handler:
+        auth:
+          url: http://localhost:8080
+        name: handler
+        state: absent
+
+    - name: Get all socket handlers
+      handler_info:
+        auth:
+          url: http://localhost:8080
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 1
+          - result.objects.0.metadata.name == 'minimal_handler'

--- a/tests/unit/modules/test_socket_handler.py
+++ b/tests/unit/modules/test_socket_handler.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    errors, utils,
+)
+from ansible_collections.sensu.sensu_go.plugins.modules import socket_handler
+
+from .common.utils import (
+    AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args,
+)
+
+
+class TestSocketHandler(ModuleTestCase):
+    def test_minimal_socket_handler_parameters(self, mocker):
+        sync_mock = mocker.patch.object(utils, "sync")
+        sync_mock.return_value = True, {}
+        set_module_args(
+            name="test_handler",
+            type='tcp',
+            host='10.0.1.99',
+            port=4444
+        )
+
+        with pytest.raises(AnsibleExitJson):
+            socket_handler.main()
+
+        state, _client, path, payload, check_mode = sync_mock.call_args[0]
+        assert state == "present"
+        assert path == "/handlers/test_handler"
+        assert payload == dict(
+            type='tcp',
+            socket=dict(
+                host='10.0.1.99',
+                port=4444
+            ),
+            metadata=dict(
+                name="test_handler",
+                namespace="default",
+            ),
+        )
+        assert check_mode is False
+
+    def test_all_socket_handler_parameters(self, mocker):
+        sync_mock = mocker.patch.object(utils, "sync")
+        sync_mock.return_value = True, {}
+        set_module_args(
+            name='test_handler',
+            state='absent',
+            type='udp',
+            filters=['occurrences', 'production'],
+            mutator='only_check_output',
+            timeout=30,
+            host='10.0.1.99',
+            port=4444
+        )
+
+        with pytest.raises(AnsibleExitJson):
+            socket_handler.main()
+
+        state, _client, path, payload, check_mode = sync_mock.call_args[0]
+        assert state == "absent"
+        assert path == "/handlers/test_handler"
+        assert payload == dict(
+            type='udp',
+            filters=['occurrences', 'production'],
+            mutator='only_check_output',
+            timeout=30,
+            socket=dict(
+                host='10.0.1.99',
+                port=4444
+            ),
+            metadata=dict(
+                name="test_handler",
+                namespace="default",
+            ),
+        )
+        assert check_mode is False
+
+    def test_failure(self, mocker):
+        sync_mock = mocker.patch.object(utils, "sync")
+        sync_mock.side_effect = errors.Error("Bad error")
+        set_module_args(
+            name='test_handler',
+            state='absent',
+            type='udp',
+            host='10.0.1.99',
+            port=4444
+        )
+
+        with pytest.raises(AnsibleFailJson):
+            socket_handler.main()


### PR DESCRIPTION
With this commit we introduce module that manages TCP/UDP sensu handler. PR is dependent on https://github.com/sensu/sensu-go-ansible/pull/35 which includes `handler_info` module, that is required for integration tests of this module.

Addressing issue: https://github.com/sensu/sensu-go-ansible/issues/20