### PR TITLE
Set `gather_facts: no` for module integration tests

### DIFF
--- a/tests/integration/modules/molecule/asset/playbook.yml
+++ b/tests/integration/modules/molecule/asset/playbook.yml
@@ -3,7 +3,7 @@
   collections:
     - sensu.sensu_go
   hosts: all
-  gather_facts: true
+  gather_facts: no
   tasks:
     - name: Create an asset
       asset:

--- a/tests/integration/modules/molecule/check/playbook.yml
+++ b/tests/integration/modules/molecule/check/playbook.yml
@@ -3,7 +3,7 @@
   collections:
     - sensu.sensu_go
   hosts: all
-  gather_facts: true
+  gather_facts: no
   tasks:
     - name: Create a check with missing required parameters
       check:

--- a/tests/integration/modules/molecule/pipe_handler/playbook.yml
+++ b/tests/integration/modules/molecule/pipe_handler/playbook.yml
@@ -3,7 +3,7 @@
   collections:
     - sensu.sensu_go
   hosts: all
-  gather_facts: true
+  gather_facts: no
   tasks:
     - name: Create pipe handler with minimal parameters
       pipe_handler:

--- a/tests/integration/modules/molecule/sensu_go_filter/playbook.yml
+++ b/tests/integration/modules/molecule/sensu_go_filter/playbook.yml
@@ -3,7 +3,7 @@
   collections:
     - sensu.sensu_go
   hosts: all
-  gather_facts: true
+  gather_facts: no
   tasks:
     - name: Create a filter
       sensu_go_filter:

--- a/tests/integration/modules/molecule/sensu_go_mutator/playbook.yml
+++ b/tests/integration/modules/molecule/sensu_go_mutator/playbook.yml
@@ -3,7 +3,7 @@
   collections:
     - sensu.sensu_go
   hosts: all
-  gather_facts: true
+  gather_facts: no
   tasks:
     - name: Create a mutator
       sensu_go_mutator:


### PR DESCRIPTION
It's time to start resolving the issues :) 
This one sets the `gather_facts` of module integration tests to `false`.

Closes: #37 