### PR TITLE
Stable test fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,10 @@ workflows:
       - modules_integration_ansible29_git
       - install_role_integration_ansible29_git
 
+      - modules_integration_ansible29_galaxy: &stable_filter
+          filters: { branches: { only: [ stable ] } }
+      - install_role_integration_ansible29_galaxy: *stable_filter
+
   daily_master:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
     executor: python37
     environment:
       ANSIBLE_VERSION: ==2.9.0b1
-      INTEGRATION_TEST_SECTION: role/installs
+      INTEGRATION_TEST_SECTION: roles/install
     steps: [ integration_test_galaxy ]
 
 commands:


### PR DESCRIPTION
The first commit in this PR fixes a typo that caused the daily test against a released version of collection to fail. The second commit adds additional checks on the `stable` branch. Running them as soon as we release a new stable version should allow us to catch any bugs faster.