### PR TITLE
Add initial support for backend config

### DIFF
--- a/roles/backend/README.md
+++ b/roles/backend/README.md
@@ -11,16 +11,51 @@ This role has no requirements.
 Role Variables
 --------------
 
-Most variables are directly interpolated into the /etc/sensu/backend.yml configuration file
-which is documented in the [official Sensu documentation][backend-conf]. Please refer to it to
-learn what exactly each specific parameter does.
+The role uses the `backend_config` top-level variable to populate the Sensu
+backend's `/etc/sensu/backend.yml`configuration file as is documented in the
+[official Sensu documentation][backend-conf]. The following `backend_config.*`
+variables can be used in the playbooks:
 
-| Variable            | Default Value | Description |
-|---------------------|---------------|-------------|
-| backend_debug       | /             | see [Sensu docs][backend-conf]
-| backend_log_level   | /             | see [Sensu docs][backend-conf]
+| Variable    | Examples  | Description |
+|-------------|-----------|-------------|
+| debug       | false     | Enable debugging and profiling features |
+| log-level   | panic/fatal/error/*warn*/info/debug | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug` |
+| agent-host  | "[::]"    | agent listener host, listens on all IPv4 and IPv6 addresses by default |
+| agent-port  | 8081      | agent listener port |
+| deregistration-handler | /path/to/handler.sh | Default event handler to use when processing agent deregistration events |
+| api-listen-address | "[::]:8080" | Address the API daemon will listen for requests on |
+| api-url     | "http://localhost:8080" | URL used to connect to the API |
+| dashboard-host | "[::]"    | Dashboard listener host |
+| dashboard-port | 3000      | Dashboard listener port |
+| etcd-advertise-client-urls | "http://localhost:2379" |
+| etcd-cert-file | "/path/to/ssl/cert.pem" | List of this member's client URLs to advertise to the rest of the cluster. |
+| etcd-client-cert-auth | false | Path to the etcd client API TLS cert file. Secures communication between the embedded etcd client API and any etcd clients. |
+| etcd-initial-advertise-peer-urls | "http://127.0.0.1:2380" | List of this member's peer URLs to advertise to the rest of the cluster |
+| etcd-initial-cluster | "default=http://127.0.0.1:2380" | Initial cluster configuration for bootstrapping |
+| etcd-initial-cluster-state | new/existing | Initial cluster state (`new` or `existing`) |
+| etcd-initial-cluster-token | "sensu" | Initial cluster token for the etcd cluster during bootstrap |
+| etcd-key-file | "/path/to/ssl/key.pem" | Path to the etcd client API TLS key file. Secures communication between the embedded etcd client API and any etcd clients |
+| etcd-listen-client-urls | "http://127.0.0.1:2379" | List of URLs to listen on for client traffic |
+| etcd-listen-peer-urls | "http://127.0.0.1:2380" | List of URLs to listen on for peer traffic |
+| etcd-name | "default" | Human-readable name for this member |
+| etcd-peer-cert-file | "/path/to/ssl/cert.pem" | Path to the peer server TLS cert file |
+| etcd-peer-client-cert-auth | false | Enable peer client cert authentication |
+| etcd-peer-key-file | "/path/to/ssl/key.pem" | Path to the etcd peer API TLS key file. Secures communication between etcd cluster members |
+| etcd-peer-trusted-ca-file | "/path/to/ssl/key.pem" | Path to the etcd peer API server TLS trusted CA file. This certificate secures communication between etcd cluster members |
+| etcd-trusted-ca-file | "/path/to/ssl/key.pem" | Path to the client server TLS trusted CA cert file. Secures communication with the etcd client server |
+| no-embed-etcd | false | Don't embed etcd, use external etcd instead |
+| etcd-cipher-suites | [] | List of allowed cipher suites for etcd TLS configuration. Sensu supports TLS 1.0-1.2 cipher suites as listed in the [Go TLS documentation][]. You can use this attribute to defend your TLS servers from attacks on weak TLS ciphers. The default cipher suites are determined by Go, based on the hardware used. |
+
+
+All of the `backend_config` variables are optional, so when we omit them from
+the role, the Sensu backend will use a version-specific default.
+The role automatically sets the following `backend_config` variables, so
+assigning custom values to them might have unexpected results:
+
+* `state-dir`
 
 [backend-conf]: https://docs.sensu.io/sensu-go/latest/reference/backend/#configuration-summary
+[Go TLS documentation]: https://golang.org/pkg/crypto/tls/#pkg-constants
 
 
 Supported Tags

--- a/roles/backend/defaults/main.yml
+++ b/roles/backend/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # Related to /etc/sensu/backend.yml, see
 # https://docs.sensu.io/sensu-go/latest/reference/backend/#configuration-summary
-backend_debug: # yes/*no*
-backend_log_level: # panic/fatal/error/*warn*/info/debug
+
+backend_config:

--- a/roles/backend/templates/backend.yml.j2
+++ b/roles/backend/templates/backend.yml.j2
@@ -3,17 +3,8 @@
 # {{ managed }}
 #
 
-##
-# Sensu backend configuration
-##
-{# -------------------------------------- #}
-{% if backend_debug %}
-debug: {{ backend_debug }}
-{% endif %}
-{# -------------------------------------- #}
-{% if backend_log_level %}
-log-level: {{ backend_log_level }}
-{% endif %}
-{# -------------------------------------- #}
 state-dir: "/var/lib/sensu/sensu-backend"
-{# -------------------------------------- #}
+
+{% if backend_config %}
+{{ backend_config | to_nice_yaml }}
+{% endif %}

--- a/tests/integration/roles/backend/molecule/config/Dockerfile.j2
+++ b/tests/integration/roles/backend/molecule/config/Dockerfile.j2
@@ -1,0 +1,1 @@
+../shared/Dockerfile.j2

--- a/tests/integration/roles/backend/molecule/config/molecule.yml
+++ b/tests/integration/roles/backend/molecule/config/molecule.yml
@@ -1,0 +1,6 @@
+---
+scenario:
+  name: config
+platforms:
+  # CentOS
+  - { groups: [backends], pull: yes, networks: [{name: common}], name: centos-7, image: centos:7 }

--- a/tests/integration/roles/backend/molecule/config/playbook.yml
+++ b/tests/integration/roles/backend/molecule/config/playbook.yml
@@ -1,0 +1,81 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - sensu.sensu_go.backend
+
+- name: Verify configure_backend
+  hosts: backends
+  vars:
+    backend_yml: /etc/sensu/backend.yml
+  tasks:
+    - name: Backend configuration must exist
+      stat:
+        path: '{{ backend_yml }}'
+      register: result
+
+    - assert:
+        that:
+          - result.stat.exists
+
+    - name: Confirm default configuration settings
+      lineinfile:
+        path: '{{ backend_yml }}'
+        line: '{{ item }}'
+      with_items:
+        - 'state-dir: "/var/lib/sensu/sensu-backend"'
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+- name: Configure full set of optional variables
+  hosts: backends
+  vars:
+    backend_config:
+      debug: yes
+      log-level: debug
+      deregistration-handler: /tmp/handler.sh
+      agent-host: "127.0.0.1"
+      agent-port: 4431
+      api-listen-address: "[::]:4430"
+      api-url: "http://localhost:4432"
+      dashboard-host: "192.168.10.6"
+      dashboard-port: 4433
+      etcd-initial-advertise-peer-urls:
+        - https://10.10.0.1:2380
+        - https://10.20.0.1:2380
+  tags:
+    - configure_backend
+  become: yes
+  roles:
+    - role: sensu.sensu_go.backend
+
+- name: Verify configure_backend full set of optional variables
+  hosts: backends
+  vars:
+    backend_yml: /etc/sensu/backend.yml
+  tasks:
+    - name: Confirm full configuration settings
+      lineinfile:
+        path: '{{ backend_yml }}'
+        line: '{{ item }}'
+      with_items:
+        - 'state-dir: "/var/lib/sensu/sensu-backend"'
+        - 'debug: true'
+        - 'log-level: debug'
+        - 'agent-host: 127.0.0.1'
+        - 'agent-port: 4431'
+        - "api-listen-address: '[::]:4430'"
+        - 'api-url: http://localhost:4432'
+        - 'dashboard-host: 192.168.10.6'
+        - 'dashboard-port: 4433'
+        - 'etcd-initial-advertise-peer-urls:'
+        - '- https://10.10.0.1:2380'
+        - '- https://10.20.0.1:2380'
+      register: result
+
+    - assert:
+        that:
+          - result is not changed


### PR DESCRIPTION
This expands the list of supported variables in the role, which translate into the Sensu backend's configuration file.

This commit addresses the configurations of Sensu backend and Sensu agent, the API and dashboard. I skipped the settings that I consider managed and the subject of future commits: caching, KPI-related settings, and etcd store settings.

References:
  * https://docs.sensu.io/sensu-go/5.14/reference/backend/#configuration
  * https://docs.sensu.io/sensu-go/5.14/files/backend.yml