### PR TITLE
Address special case backend configs

### DIFF
--- a/roles/backend/README.md
+++ b/roles/backend/README.md
@@ -18,6 +18,7 @@ variables can be used in the playbooks:
 
 | Variable    | Examples  | Description |
 |-------------|-----------|-------------|
+| state-dir   | /var/lib/sensu/sensu-backend | Path to Sensu state storage. Default value: `/var/lib/sensu/sensu-backend`. |
 | debug       | false     | Enable debugging and profiling features |
 | log-level   | panic/fatal/error/*warn*/info/debug | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug` |
 | agent-host  | "[::]"    | agent listener host, listens on all IPv4 and IPv6 addresses by default |
@@ -49,10 +50,6 @@ variables can be used in the playbooks:
 
 All of the `backend_config` variables are optional, so when we omit them from
 the role, the Sensu backend will use a version-specific default.
-The role automatically sets the following `backend_config` variables, so
-assigning custom values to them might have unexpected results:
-
-* `state-dir`
 
 [backend-conf]: https://docs.sensu.io/sensu-go/latest/reference/backend/#configuration-summary
 [Go TLS documentation]: https://golang.org/pkg/crypto/tls/#pkg-constants

--- a/roles/backend/templates/backend.yml.j2
+++ b/roles/backend/templates/backend.yml.j2
@@ -3,7 +3,9 @@
 # {{ managed }}
 #
 
+{% if not backend_config or "state-dir" not in backend_config %}
 state-dir: "/var/lib/sensu/sensu-backend"
+{% endif %}
 
 {% if backend_config %}
 {{ backend_config | to_nice_yaml }}

--- a/tests/integration/roles/backend/molecule/config/playbook.yml
+++ b/tests/integration/roles/backend/molecule/config/playbook.yml
@@ -30,12 +30,45 @@
         that:
           - result is not changed
 
+- name: Configure select set of optional variables
+  hosts: backends
+  vars:
+    backend_config:
+      debug: no
+      log-level: debug
+      api-listen-address: "[::]:4430"
+  tags:
+    - configure_backend
+  become: yes
+  roles:
+    - role: sensu.sensu_go.backend
+
+- name: Verify configure_backend select set of optional variables
+  hosts: backends
+  vars:
+    backend_yml: /etc/sensu/backend.yml
+  tasks:
+    - name: Confirm optional configuration settings
+      lineinfile:
+        path: '{{ backend_yml }}'
+        line: '{{ item }}'
+      with_items:
+        - 'state-dir: "/var/lib/sensu/sensu-backend"'
+        - 'debug: false'
+        - "api-listen-address: '[::]:4430'"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
 - name: Configure full set of optional variables
   hosts: backends
   vars:
     backend_config:
       debug: yes
       log-level: debug
+      state-dir: /tmp/different/state
       deregistration-handler: /tmp/handler.sh
       agent-host: "127.0.0.1"
       agent-port: 4431
@@ -60,20 +93,22 @@
     - name: Confirm full configuration settings
       lineinfile:
         path: '{{ backend_yml }}'
-        line: '{{ item }}'
+        line: '{{ item.ln }}'
+        state: '{{ item.state }}'
       with_items:
-        - 'state-dir: "/var/lib/sensu/sensu-backend"'
-        - 'debug: true'
-        - 'log-level: debug'
-        - 'agent-host: 127.0.0.1'
-        - 'agent-port: 4431'
-        - "api-listen-address: '[::]:4430'"
-        - 'api-url: http://localhost:4432'
-        - 'dashboard-host: 192.168.10.6'
-        - 'dashboard-port: 4433'
-        - 'etcd-initial-advertise-peer-urls:'
-        - '- https://10.10.0.1:2380'
-        - '- https://10.20.0.1:2380'
+        - {ln: 'state-dir: "/var/lib/sensu/sensu-backend"', state: absent}
+        - {ln: 'state-dir: /tmp/different/state', state: present}
+        - {ln: 'debug: true', state: present}
+        - {ln: 'log-level: debug', state: present}
+        - {ln: 'agent-host: 127.0.0.1', state: present}
+        - {ln: 'agent-port: 4431', state: present}
+        - {ln: "api-listen-address: '[::]:4430'", state: present}
+        - {ln: 'api-url: http://localhost:4432', state: present}
+        - {ln: 'dashboard-host: 192.168.10.6', state: present}
+        - {ln: 'dashboard-port: 4433', state: present}
+        - {ln: 'etcd-initial-advertise-peer-urls:', state: present}
+        - {ln: '- https://10.10.0.1:2380', state: present}
+        - {ln: '- https://10.20.0.1:2380', state: present}
       register: result
 
     - assert:


### PR DESCRIPTION
We now allow for a user change of the configurations that were previously baked into the template: `state-dir`.