### PR TITLE
Clean up asset's documentation

### DIFF
--- a/plugins/modules/asset.py
+++ b/plugins/modules/asset.py
@@ -40,24 +40,20 @@ options:
     description:
       - The URL location of the asset.
     type: str
-    required: true
   sha512:
     description:
       - The checksum of the asset.
     type: str
-    required: true
   filters:
     description:
       - A set of Sensu query expressions used to determine if the asset
         should be installed.
     type: list
-    default: []
   headers:
     description:
       - Additional headers to send when retrieving the asset, e.g. for
         authorization.
     type: dict
-    default: {}
 """
 
 EXAMPLES = """


### PR DESCRIPTION
Cleaned up some required values that are only required when creating asset and some default values that are not actually defaults. I'm wondering why ansible sanity tester didn't complain.