### PR TITLE
Bump Ansible version to 2.9.0rc4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
   sanity:
     executor: python37
     environment:
-      ANSIBLE_VERSION: ==2.9.0rc1
+      ANSIBLE_VERSION: ==2.9.0rc4
       TEST_KIND: sanity
     steps: [ sanity_test ]
 
@@ -78,7 +78,7 @@ jobs:
   unit_python27_ansible29:
     executor: python27
     environment:
-      ANSIBLE_VERSION: ==2.9.0rc1
+      ANSIBLE_VERSION: ==2.9.0rc4
       TEST_KIND: units
       TEST_ARGS: --verbose --coverage
     steps: [ unit_test ]
@@ -86,7 +86,7 @@ jobs:
   unit_python35_ansible29:
     executor: python35
     environment:
-      ANSIBLE_VERSION: ==2.9.0rc1
+      ANSIBLE_VERSION: ==2.9.0rc4
       TEST_KIND: units
       TEST_ARGS: --verbose --coverage
     steps: [ unit_test ]
@@ -94,7 +94,7 @@ jobs:
   unit_python36_ansible29:
     executor: python36
     environment:
-      ANSIBLE_VERSION: ==2.9.0rc1
+      ANSIBLE_VERSION: ==2.9.0rc4
       TEST_KIND: units
       TEST_ARGS: --verbose --coverage
     steps: [ unit_test ]
@@ -102,7 +102,7 @@ jobs:
   unit_python37_ansible29:
     executor: python37
     environment:
-      ANSIBLE_VERSION: ==2.9.0rc1
+      ANSIBLE_VERSION: ==2.9.0rc4
       TEST_KIND: units
       TEST_ARGS: --verbose --coverage
     steps: [ unit_test ]
@@ -112,21 +112,21 @@ jobs:
   modules_integration_ansible29_git: &modules_integration
     executor: python37
     environment:
-      ANSIBLE_VERSION: ==2.9.0rc1
+      ANSIBLE_VERSION: ==2.9.0rc4
       INTEGRATION_TEST_SECTION: modules
     steps: [ integration_test_git ]
 
   install_role_integration_ansible29_git: &install_role
     executor: python37
     environment:
-      ANSIBLE_VERSION: ==2.9.0rc1
+      ANSIBLE_VERSION: ==2.9.0rc4
       INTEGRATION_TEST_SECTION: roles/install
     steps: [ integration_test_git ]
 
   backend_role_integration_ansible29_git: &backend_role
     executor: python37
     environment:
-      ANSIBLE_VERSION: ==2.9.0rc1
+      ANSIBLE_VERSION: ==2.9.0rc4
       INTEGRATION_TEST_SECTION: roles/backend
     steps: [ integration_test_git ]
 


### PR DESCRIPTION
Previous versions of Ansible have troubles installing collections from the Ansible galaxy.