### PR TITLE
Add metadata to roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ tests/runner
 .pytest_cache
 *.pyc
 *.swp
-meta

--- a/roles/agent/meta/main.yml
+++ b/roles/agent/meta/main.yml
@@ -1,0 +1,21 @@
+galaxy_info:
+  author: XLAB Steampunk <steampunk@xlab.si>
+  description: Configure Sensu Go agent
+  license: GPL-3.0-or-later
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - "6"
+        - "7"
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
+        - bionic
+        - cosmic
+        - disco dingo
+
+  galaxy_tags:
+    - sensu

--- a/roles/backend/meta/main.yml
+++ b/roles/backend/meta/main.yml
@@ -1,0 +1,21 @@
+galaxy_info:
+  author: XLAB Steampunk <steampunk@xlab.si>
+  description: Configure Sensu Go backend
+  license: GPL-3.0-or-later
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - "6"
+        - "7"
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
+        - bionic
+        - cosmic
+        - disco dingo
+
+  galaxy_tags:
+    - sensu

--- a/roles/install/meta/main.yml
+++ b/roles/install/meta/main.yml
@@ -1,0 +1,21 @@
+galaxy_info:
+  author: XLAB Steampunk <steampunk@xlab.si>
+  description: Install Sensu Go components
+  license: GPL-3.0-or-later
+  min_ansible_version: 2.8
+
+  platforms:
+    - name: EL
+      versions:
+        - "6"
+        - "7"
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
+        - bionic
+        - cosmic
+        - disco dingo
+
+  galaxy_tags:
+    - sensu


### PR DESCRIPTION
Up until now, we had no metadata attached to the individual roles and galaxy.ansible.com was completely fine with this. But today, things started failing when we tried to publish a new release of our collection. ansible-galaxy command reported back this:

  Galaxy import process failed: Role metadata not found (Code: GLW0002)

A quick search through the galaxy sources revealed that this error is raised if no metadata file can be found in the role directory. And here we are, adding a fresh set of metadata to our roles.

Does this fix our publish problem? Heck if I know ;) I think it might, but cannot be sure.