### PR TITLE
Split CI pipeline into stages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,26 @@ workflows:
       - unit_python36_ansible29
       - unit_python37_ansible29
 
-      - modules_integration_ansible29_git
-      - install_role_integration_ansible29_git
-      - backend_role_integration_ansible29_git
+      - modules_integration_ansible29_git: &master_opts
+          requires:
+            - sanity
+            - unit_python27_ansible29
+            - unit_python35_ansible29
+            - unit_python36_ansible29
+            - unit_python37_ansible29
+      - install_role_integration_ansible29_git: *master_opts
+      - backend_role_integration_ansible29_git: *master_opts
 
-      - modules_integration_ansible29_galaxy: &stable_filter
+      - modules_integration_ansible29_galaxy: &stable_opts
           filters: { branches: { only: [ stable ] } }
-      - install_role_integration_ansible29_galaxy: *stable_filter
-      - backend_role_integration_ansible29_galaxy: *stable_filter
+          requires:
+            - sanity
+            - unit_python27_ansible29
+            - unit_python35_ansible29
+            - unit_python36_ansible29
+            - unit_python37_ansible29
+      - install_role_integration_ansible29_galaxy: *stable_opts
+      - backend_role_integration_ansible29_galaxy: *stable_opts
 
   daily_master:
     triggers:


### PR DESCRIPTION
Up until now we ran all of our jobs in parallel. And while this sounds great in theory, it wastes quite a few resources when one of the short-running tests fail.

This is why we split the CI jobs into two categories: fast and slow ones. Now we first run the fast ones and then proceed to run slow ones. Note that the slow jobs are only run if all of the fast ones finished successfully.

This saves a ton if resources if one of the fast tests fails.

/cc @mancabizjak 