### PR TITLE
Make argument spec composable

### DIFF
--- a/plugins/doc_fragments/annotations.py
+++ b/plugins/doc_fragments/annotations.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = """
+options:
+  annotations:
+    description:
+      - Custom metadata fields with fewer restrictions, as key/value pairs.
+      - These are preserved by Sensu but not accessible as tokens or
+        identifiers, and are mainly intended for use with external tools.
+    type: dict
+"""

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = """
+options:
+  auth:
+    description:
+      - Authentication parameters. Can define each of them with ENV as well.
+    type: dict
+    suboptions:
+      user:
+        description:
+          - The username to use for connecting to the Sensu API.
+            If this is not set the value of the SENSU_USER environment
+            variable will be checked.
+        type: str
+        default: admin
+      password:
+        description:
+          - The Sensu user's password.
+            If this is not set the value of the SENSU_PASSWORD environment
+            variable will be checked.
+        type: str
+        default: P@ssw0rd!
+      url:
+        description:
+          - Location of the Sensu backend API.
+            If this is not set the value of the SENSU_URL environment variable
+            will be checked.
+        type: str
+        default: http://localhost:8080
+      namespace:
+        description:
+          - RBAC namespace to operate in.
+            If this is not set the value of the SENSU_NAMESPACE environment
+            variable will be checked.
+        type: str
+        default: default
+"""

--- a/plugins/doc_fragments/labels.py
+++ b/plugins/doc_fragments/labels.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = """
+options:
+  labels:
+    description:
+      - Custom metadata fields that can be accessed within Sensu, as key/value
+        pairs.
+    type: dict
+"""

--- a/plugins/doc_fragments/name.py
+++ b/plugins/doc_fragments/name.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = """
+options:
+  name:
+    description:
+      - The Sensu object's name.
+    type: str
+    required: yes
+"""

--- a/plugins/doc_fragments/state.py
+++ b/plugins/doc_fragments/state.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = """
+options:
+  state:
+    description:
+      - Target state of the Sensu object.
+    type: str
+    choices: [ present, absent ]
+    default: present
+"""

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -11,7 +11,7 @@ from ansible.module_utils.basic import env_fallback
 from ansible_collections.sensu.sensu_go.plugins.module_utils import client
 
 
-COMMON_ARGUMENTS = dict(
+SHARED_SPECS = dict(
     auth=dict(
         type="dict",
         apply_defaults=True,
@@ -34,11 +34,7 @@ COMMON_ARGUMENTS = dict(
                 fallback=(env_fallback, ["SENSU_NAMESPACE"]),
             )
         ),
-    )
-)
-
-OBJECT_ARGUMENTS = dict(
-    COMMON_ARGUMENTS,
+    ),
     state=dict(
         default="present",
         choices=["present", "absent"],
@@ -46,10 +42,6 @@ OBJECT_ARGUMENTS = dict(
     name=dict(
         required=True,
     ),
-)
-
-MUTATION_ARGUMENTS = dict(
-    OBJECT_ARGUMENTS,
     labels=dict(
         type="dict",
         default={},
@@ -59,6 +51,10 @@ MUTATION_ARGUMENTS = dict(
         default={},
     ),
 )
+
+
+def get_spec(*param_names):
+    return {p: SHARED_SPECS[p] for p in param_names}
 
 
 def get_spec_payload(source, *wanted_params):

--- a/plugins/module_utils/base.py
+++ b/plugins/module_utils/base.py
@@ -14,7 +14,7 @@ import json
 
 
 def sensu_argument_spec():
-    return arguments.COMMON_ARGUMENTS.copy()
+    return arguments.get_spec("auth")
 
 
 def clean_metadata_dict(tags):

--- a/plugins/modules/asset.py
+++ b/plugins/modules/asset.py
@@ -27,8 +27,11 @@ description:
     U(https://docs.sensu.io/sensu-go/latest/reference/assets/)
 version_added: 0.1.0
 extends_documentation_fragment:
-  - sensu.sensu_go.base
-  - sensu.sensu_go.object
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+  - sensu.sensu_go.labels
+  - sensu.sensu_go.annotations
 options:
   state:
     description:

--- a/plugins/modules/asset.py
+++ b/plugins/modules/asset.py
@@ -95,7 +95,9 @@ def main():
         required_if=required_if,
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.MUTATION_ARGUMENTS,
+            arguments.get_spec(
+                "auth", "name", "state", "labels", "annotations",
+            ),
             url=dict(),
             sha512=dict(),
             filters=dict(

--- a/plugins/modules/asset_info.py
+++ b/plugins/modules/asset_info.py
@@ -55,8 +55,8 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.COMMON_ARGUMENTS,
-            name=dict(),
+            arguments.get_spec("auth"),
+            name=dict(),  # Name is not required in info modules.
         ),
     )
 

--- a/plugins/modules/asset_info.py
+++ b/plugins/modules/asset_info.py
@@ -27,7 +27,7 @@ description:
     U(https://docs.sensu.io/sensu-go/latest/reference/assets/)
 version_added: 0.0.1
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
   - sensu.sensu_go.info
 """
 

--- a/plugins/modules/check.py
+++ b/plugins/modules/check.py
@@ -26,8 +26,11 @@ description:
     U(https://docs.sensu.io/sensu-go/latest/reference/checks/)
 version_added: 0.1.0
 extends_documentation_fragment:
-  - sensu.sensu_go.base
-  - sensu.sensu_go.object
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+  - sensu.sensu_go.labels
+  - sensu.sensu_go.annotations
 options:
   command:
     description:

--- a/plugins/modules/check.py
+++ b/plugins/modules/check.py
@@ -239,7 +239,9 @@ def main():
         required_if=required_if,
         mutually_exclusive=mutually_exclusive,
         argument_spec=dict(
-            arguments.MUTATION_ARGUMENTS,
+            arguments.get_spec(
+                "auth", "name", "state", "labels", "annotations",
+            ),
             command=dict(),
             subscriptions=dict(
                 type='list'

--- a/plugins/modules/check_info.py
+++ b/plugins/modules/check_info.py
@@ -24,7 +24,7 @@ description:
   - 'For more information, refer to the Sensu documentation: U(https://docs.sensu.io/sensu-go/latest/reference/checks/)'
 version_added: 0.1.0
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
   - sensu.sensu_go.info
 '''
 

--- a/plugins/modules/check_info.py
+++ b/plugins/modules/check_info.py
@@ -51,8 +51,8 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.COMMON_ARGUMENTS,
-            name=dict(),
+            arguments.get_spec("auth"),
+            name=dict(),  # Name is not required in info modules.
         ),
     )
 

--- a/plugins/modules/entity.py
+++ b/plugins/modules/entity.py
@@ -24,8 +24,11 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/entities/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
-  - sensu.sensu_go.object
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+  - sensu.sensu_go.labels
+  - sensu.sensu_go.annotations
 options:
   entity_class:
     description:

--- a/plugins/modules/entity.py
+++ b/plugins/modules/entity.py
@@ -121,7 +121,9 @@ def main():
         required_if=required_if,
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.MUTATION_ARGUMENTS,
+            arguments.get_spec(
+                "auth", "name", "state", "labels", "annotations",
+            ),
             entity_class=dict(),
             subscriptions=dict(
                 type='list',

--- a/plugins/modules/entity_info.py
+++ b/plugins/modules/entity_info.py
@@ -51,8 +51,8 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.COMMON_ARGUMENTS,
-            name=dict(),
+            arguments.get_spec("auth"),
+            name=dict(),  # Name is not required in info modules.
         ),
     )
 

--- a/plugins/modules/entity_info.py
+++ b/plugins/modules/entity_info.py
@@ -24,7 +24,7 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/entities/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
   - sensu.sensu_go.info
 '''
 

--- a/plugins/modules/filter.py
+++ b/plugins/modules/filter.py
@@ -101,7 +101,9 @@ def main():
         required_if=required_if,
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.MUTATION_ARGUMENTS,
+            arguments.get_spec(
+                "auth", "name", "state", "labels", "annotations",
+            ),
             action=dict(choices=['allow', 'deny']),
             expressions=dict(
                 type='list',

--- a/plugins/modules/filter.py
+++ b/plugins/modules/filter.py
@@ -24,8 +24,11 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/filters/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
-  - sensu.sensu_go.object
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+  - sensu.sensu_go.labels
+  - sensu.sensu_go.annotations
 options:
   action:
     description:

--- a/plugins/modules/filter_info.py
+++ b/plugins/modules/filter_info.py
@@ -51,8 +51,8 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.COMMON_ARGUMENTS,
-            name=dict(),
+            arguments.get_spec("auth"),
+            name=dict(),  # Name is not required in info modules.
         ),
     )
 

--- a/plugins/modules/filter_info.py
+++ b/plugins/modules/filter_info.py
@@ -24,7 +24,7 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/filters/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
   - sensu.sensu_go.info
 '''
 

--- a/plugins/modules/handler_info.py
+++ b/plugins/modules/handler_info.py
@@ -22,7 +22,7 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/handlers/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
   - sensu.sensu_go.info
 '''
 

--- a/plugins/modules/handler_info.py
+++ b/plugins/modules/handler_info.py
@@ -49,8 +49,8 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.COMMON_ARGUMENTS,
-            name=dict(),
+            arguments.get_spec("auth"),
+            name=dict(),  # Name is not required in info modules.
         ),
     )
 

--- a/plugins/modules/handler_set.py
+++ b/plugins/modules/handler_set.py
@@ -22,8 +22,11 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/handlers/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
-  - sensu.sensu_go.object
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+  - sensu.sensu_go.labels
+  - sensu.sensu_go.annotations
 options:
   handlers:
     description:

--- a/plugins/modules/handler_set.py
+++ b/plugins/modules/handler_set.py
@@ -63,7 +63,9 @@ def main():
         supports_check_mode=True,
         required_if=required_if,
         argument_spec=dict(
-            arguments.MUTATION_ARGUMENTS,
+            arguments.get_spec(
+                "auth", "name", "state", "labels", "annotations",
+            ),
             handlers=dict(
                 type='list'
             ),

--- a/plugins/modules/hook.py
+++ b/plugins/modules/hook.py
@@ -88,7 +88,9 @@ def main():
         required_if=required_if,
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.MUTATION_ARGUMENTS,
+            arguments.get_spec(
+                "auth", "name", "state", "labels", "annotations",
+            ),
             command=dict(),
             timeout=dict(
                 type='int',

--- a/plugins/modules/hook.py
+++ b/plugins/modules/hook.py
@@ -24,8 +24,11 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/hooks/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
-  - sensu.sensu_go.object
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+  - sensu.sensu_go.labels
+  - sensu.sensu_go.annotations
 options:
   command:
     description:

--- a/plugins/modules/hook_info.py
+++ b/plugins/modules/hook_info.py
@@ -24,7 +24,7 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/hooks/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
   - sensu.sensu_go.info
 '''
 

--- a/plugins/modules/hook_info.py
+++ b/plugins/modules/hook_info.py
@@ -56,8 +56,8 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.COMMON_ARGUMENTS,
-            name=dict(),
+            arguments.get_spec("auth"),
+            name=dict(),  # Name is not required in info modules.
         ),
     )
 

--- a/plugins/modules/mutator.py
+++ b/plugins/modules/mutator.py
@@ -24,8 +24,11 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/mutators/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
-  - sensu.sensu_go.object
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+  - sensu.sensu_go.labels
+  - sensu.sensu_go.annotations
 options:
   command:
     description:

--- a/plugins/modules/mutator.py
+++ b/plugins/modules/mutator.py
@@ -81,7 +81,9 @@ def main():
         required_if=required_if,
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.MUTATION_ARGUMENTS,
+            arguments.get_spec(
+                "auth", "name", "state", "labels", "annotations",
+            ),
             command=dict(),
             timeout=dict(
                 type='int',

--- a/plugins/modules/mutator_info.py
+++ b/plugins/modules/mutator_info.py
@@ -25,7 +25,7 @@ description:
     U(https://docs.sensu.io/sensu-go/latest/reference/mutators/)
 version_added: 0.1.0
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
   - sensu.sensu_go.info
 '''
 

--- a/plugins/modules/mutator_info.py
+++ b/plugins/modules/mutator_info.py
@@ -52,8 +52,8 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.COMMON_ARGUMENTS,
-            name=dict(),
+            arguments.get_spec("auth"),
+            name=dict(),  # Name is not required in info modules.
         ),
     )
 

--- a/plugins/modules/namespace.py
+++ b/plugins/modules/namespace.py
@@ -72,7 +72,7 @@ from ansible_collections.sensu.sensu_go.plugins.module_utils import (
 def main():
     module = AnsibleModule(
         supports_check_mode=True,
-        argument_spec=arguments.OBJECT_ARGUMENTS
+        argument_spec=arguments.get_spec("auth", "name", "state"),
     )
     module.params['auth']['namespace'] = None
     client = arguments.get_sensu_client(module.params['auth'])

--- a/plugins/modules/namespace.py
+++ b/plugins/modules/namespace.py
@@ -24,21 +24,11 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#namespaces)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
 notes:
   - Parameter C(auth.namespace) is ignored in this module.
-options:
-  name:
-    description:
-      - The Sensu object's name.
-    type: str
-    required: yes
-  state:
-    description:
-      - Target state of the Sensu object.
-    type: str
-    choices: [ 'present', 'absent' ]
-    default: present
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/namespace_info.py
+++ b/plugins/modules/namespace_info.py
@@ -51,7 +51,7 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.COMMON_ARGUMENTS,
+            arguments.get_spec("auth"),
         ),
     )
     module.params['auth']['namespace'] = None

--- a/plugins/modules/namespace_info.py
+++ b/plugins/modules/namespace_info.py
@@ -23,7 +23,7 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#namespaces)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
 notes:
   - Parameters C(auth.namespace) is ignored in this module.
 '''

--- a/plugins/modules/pipe_handler.py
+++ b/plugins/modules/pipe_handler.py
@@ -87,7 +87,9 @@ def main():
         supports_check_mode=True,
         required_if=required_if,
         argument_spec=dict(
-            arguments.MUTATION_ARGUMENTS,
+            arguments.get_spec(
+                "auth", "name", "state", "labels", "annotations",
+            ),
             command=dict(),
             filters=dict(
                 type='list',

--- a/plugins/modules/pipe_handler.py
+++ b/plugins/modules/pipe_handler.py
@@ -22,8 +22,11 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/handlers/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
-  - sensu.sensu_go.object
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+  - sensu.sensu_go.labels
+  - sensu.sensu_go.annotations
 options:
   command:
     description:

--- a/plugins/modules/socket_handler.py
+++ b/plugins/modules/socket_handler.py
@@ -22,8 +22,11 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/handlers/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
-  - sensu.sensu_go.object
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+  - sensu.sensu_go.labels
+  - sensu.sensu_go.annotations
 options:
   type:
     description:

--- a/plugins/modules/socket_handler.py
+++ b/plugins/modules/socket_handler.py
@@ -95,7 +95,9 @@ def main():
         supports_check_mode=True,
         required_if=required_if,
         argument_spec=dict(
-            arguments.MUTATION_ARGUMENTS,
+            arguments.get_spec(
+                "auth", "name", "state", "labels", "annotations",
+            ),
             type=dict(choices=['tcp', 'udp']),
             filters=dict(
                 type='list',

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -98,13 +98,10 @@ def main():
         required_if=required_if,
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.COMMON_ARGUMENTS,
+            arguments.get_spec("auth", "name"),
             state=dict(
                 default='enabled',
                 choices=['enabled', 'disabled'],
-            ),
-            name=dict(
-                required=True
             ),
             password=dict(
                 no_log=True

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -23,7 +23,8 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/users/)
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
 notes:
   - Parameter C(auth.namespace) is ignored in this module.
 options:
@@ -32,13 +33,8 @@ options:
       - Desired state of the user.
       - Users cannot actually be deleted, only deactivated.
     type: str
-    choices: ['enabled', 'disabled']
+    choices: [ enabled, disabled ]
     default: enabled
-  name:
-    description:
-      - Username.
-    type: str
-    required: true
   password:
     description:
       - Password for the user.

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -53,8 +53,8 @@ def main():
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(
-            arguments.COMMON_ARGUMENTS,
-            name=dict(),
+            arguments.get_spec("auth"),
+            name=dict(),  # Name is not required in info modules.
         ),
     )
     module.params['auth']['namespace'] = None

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -26,7 +26,7 @@ description:
 notes:
   - Parameter C(auth.namespace) is ignored in this module.
 extends_documentation_fragment:
-  - sensu.sensu_go.base
+  - sensu.sensu_go.auth
   - sensu.sensu_go.info
 '''
 

--- a/tests/unit/module_utils/test_arguments.py
+++ b/tests/unit/module_utils/test_arguments.py
@@ -8,6 +8,23 @@ from ansible_collections.sensu.sensu_go.plugins.module_utils import (
 )
 
 
+class TestGetSpec:
+    @pytest.mark.parametrize("param", [
+        "auth", "state", "name", "labels", "annotations",
+    ])
+    def test_valid_parameter(self, param):
+        assert set(arguments.get_spec(param).keys()) == {param}
+
+    def test_invalid_parameter(self):
+        with pytest.raises(KeyError):
+            arguments.get_spec("bad_parameter_name")
+
+    def test_multiple_parameters(self):
+        assert set(arguments.get_spec("auth", "name", "labels").keys()) == {
+            "auth", "name", "labels",
+        }
+
+
 class TestGetSpecPayload:
     def test_no_key(self):
         params = dict(


### PR DESCRIPTION
The primary purpose of this PR is twofold. First, we tried to make modules self-documenting. And secondly, we tried to increase the malleability of the shared parameter specification and documentation.

We tried to achieve this by removing the opaque groups of shared parameters and replace them with a function call that lists what argument specifications we need. We did roughly the same thing with documentation and split it into fragments that document each share parameter separately.