### PR TITLE
Add repository channel control

### DIFF
--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 os: unknown
 dist: unknown
+channel: stable
 
 components:
   - sensu-go-backend

--- a/roles/install/tasks/apt/prepare.yml
+++ b/roles/install/tasks/apt/prepare.yml
@@ -12,17 +12,17 @@
 
 - name: Add apt key
   apt_key:
-    url: https://packagecloud.io/sensu/stable/gpgkey
+    url: https://packagecloud.io/sensu/{{ channel }}/gpgkey
     id: 0A3F7426
 
 - name: Add apt repository
   apt_repository:
-    repo: deb https://packagecloud.io/sensu/stable/{{ os }}/ {{ dist }} main
-    filename: /etc/apt/sources.list.d/sensu_stable.list
+    repo: deb https://packagecloud.io/sensu/{{ channel }}/{{ os }}/ {{ dist }} main
+    filename: /etc/apt/sources.list.d/sensu_{{ channel }}
     validate_certs: yes
 
 - name: Add apt source repository
   apt_repository:
-    repo: deb-src https://packagecloud.io/sensu/stable/{{ os }}/ {{ dist }} main
-    filename: /etc/apt/sources.list.d/sensu_stable.list
+    repo: deb-src https://packagecloud.io/sensu/{{ channel }}/{{ os }}/ {{ dist }} main
+    filename: /etc/apt/sources.list.d/sensu_{{ channel }}
     validate_certs: yes

--- a/roles/install/tasks/yum/prepare.yml
+++ b/roles/install/tasks/yum/prepare.yml
@@ -4,11 +4,11 @@
 
 - name: Add yum repository
   yum_repository:
-    name: sensu_stable
-    description: sensu_stable
+    name: sensu_{{ channel }}
+    description: sensu_{{ channel }}
     file: sensu
-    baseurl: https://packagecloud.io/sensu/stable/{{ os }}/{{ dist }}/$basearch
-    gpgkey: https://packagecloud.io/sensu/stable/gpgkey
+    baseurl: https://packagecloud.io/sensu/{{ channel }}/{{ os }}/{{ dist }}/$basearch
+    gpgkey: https://packagecloud.io/sensu/{{ channel }}/gpgkey
     gpgcheck: no
     repo_gpgcheck: yes
     enabled: yes
@@ -18,11 +18,11 @@
 
 - name: Add yum source repository
   yum_repository:
-    name: sensu_stable-source
-    description: sensu_stable-source
+    name: sensu_{{ channel }}-source
+    description: sensu_{{ channel }}-source
     file: sensu
-    baseurl: https://packagecloud.io/sensu/stable/{{ os }}/{{ dist }}/SRPMS
-    gpgkey: https://packagecloud.io/sensu/stable/gpgkey
+    baseurl: https://packagecloud.io/sensu/{{ channel }}/{{ os }}/{{ dist }}/SRPMS
+    gpgkey: https://packagecloud.io/sensu/{{ channel }}/gpgkey
     gpgcheck: no
     repo_gpgcheck: yes
     enabled: yes


### PR DESCRIPTION
This adds a channel variable to both the `yum` and `apt` repository control. This will let users control which channel is added from this list:

https://packagecloud.io/sensu

The immediate use of this will be to having the `prerelease` channel used prior to those packages being moved to `stable`. 

I also did find that the current files were being added with `.list` on the end twice for `apt` lists, like `sensu_stable.list.list`. I've removed the hard coded one from the `filename` attribute in ` roles/install/tasks/apt/prepare.yml`. While it did work, it seemed unintended. I can move that fix out of this PR if needed.

Please let me know if you'd like any tests done for this work. While I haven't done much with that yet, happy to learn and add them.

Should also be noted that this will currently not clean up the old repository, but that seems ok to me for most use cases.