### PR TITLE
Update cluster_role and cluster_role_info modules

### DIFF
--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -67,8 +67,13 @@ def get_mutation_payload(source, *wanted_params):
     payload = get_spec_payload(source, *wanted_params)
     payload["metadata"] = dict(
         name=source["name"],
-        namespace=source["auth"]["namespace"],
     )
+    # Cluster-wide objects are not limited to a single namespace. This is why we set
+    # metadata.namespace field only if namespace is present in authentication parameters.
+    namespace = source["auth"]["namespace"]
+    if namespace:
+        payload["metadata"]["namespace"] = namespace
+
     for kind in "labels", "annotations":
         if source.get(kind):
             payload["metadata"][kind] = {

--- a/plugins/module_utils/role_utils.py
+++ b/plugins/module_utils/role_utils.py
@@ -42,3 +42,36 @@ def _do_subjects_differ(a, b):
     sorted_a = sorted(a, key=lambda x: (x['type'], x['name']))
     sorted_b = sorted(b, key=lambda x: (x['type'], x['name']))
     return sorted_a != sorted_b
+
+
+def _rule_set(rules):
+    return {
+        (
+            frozenset(r.get('verbs', []) or []),
+            frozenset(r.get('resources', []) or []),
+            frozenset(r.get('resource_names', []) or [])
+        ) for r in rules
+    }
+
+
+def _do_rules_differ(current_rules, desired_rules):
+    if len(current_rules) != len(desired_rules):
+        return True
+    if _rule_set(current_rules) != _rule_set(desired_rules):
+        return True
+    return False
+
+
+def do_roles_differ(current, desired):
+    if current is None:
+        return True
+
+    for key, value in desired.items():
+        current_value = current.get(key)
+        if key == 'rules':
+            if _do_rules_differ(current_value, value):
+                return True
+        elif value != current.get(key):
+            return True
+
+    return False

--- a/plugins/modules/cluster_role.py
+++ b/plugins/modules/cluster_role.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Paul Arthur <paul.arthur@flowerysong.com>
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'XLAB Steampunk'}
+
+DOCUMENTATION = '''
+module: cluster_role
+author:
+ - Paul Arthur (@flowerysong)
+ - Manca Bizjak (@mancabizjak)
+ - Aljaz Kosir (@aljazkosir)
+ - Tadej Borovsak (@tadeboro)
+short_description: Manages Sensu cluster roles
+description:
+  - For more information, refer to the Sensu documentation at
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+extends_documentation_fragment:
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+notes:
+  - Parameter C(auth.namespace) is ignored in this module.
+options:
+  rules:
+    description:
+      - Rules that the cluster role applies.
+    type: list
+    suboptions:
+      verbs:
+        description:
+          - Permissions to be applied by the rule.
+        type: list
+        required: yes
+        choices: [get, list, create, update, delete]
+      resources:
+        description:
+          - Types of resources the rule has permission to access.
+        type: list
+        required: yes
+      resource_names:
+        description:
+          - Names of specific resources the rule has permission to access.
+          - Note that for the 'create' verb, this argument will not be
+            taken into account when enforcing RBAC, even if it is provided.
+        type: list
+'''
+
+EXAMPLES = '''
+- name: Create a cluster role
+  cluster_role:
+    name: readonly
+    rules:
+      - verbs:
+          - get
+          - list
+        resources:
+          - checks
+          - entities
+'''
+
+RETURN = '''
+object:
+    description: object representing Sensu cluster role
+    returned: success
+    type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    arguments, errors, utils, role_utils
+)
+
+
+def validate_module_params(module):
+    params = module.params
+    if params['state'] == 'present':
+        if not params['rules']:
+            module.fail_json(
+                msg='state is present but all of the following are missing: rules'
+            )
+
+
+def main():
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            arguments.get_spec("auth", "name", "state"),
+            rules=dict(
+                type="list",
+                elements="dict",
+                options=dict(
+                    verbs=dict(
+                        required=True,
+                        type="list",
+                        choices=["get", "list", "create", "update", "delete"],
+                    ),
+                    resources=dict(
+                        required=True,
+                        type="list",
+                    ),
+                    resource_names=dict(
+                        type="list",
+                    ),
+                )
+            )
+        )
+    )
+
+    validate_module_params(module)
+    module.params['auth']['namespace'] = None  # Making sure we are not fallbacking to default
+    client = arguments.get_sensu_client(module.params["auth"])
+    path = "/clusterroles/{0}".format(module.params["name"])
+    payload = arguments.get_mutation_payload(
+        module.params, "rules"
+    )
+
+    try:
+        changed, cluster_role = utils.sync(
+            module.params['state'], client, path,
+            payload, module.check_mode, role_utils.do_roles_differ
+        )
+        module.exit_json(changed=changed, object=cluster_role)
+    except errors.Error as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/cluster_role_info.py
+++ b/plugins/modules/cluster_role_info.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Paul Arthur <paul.arthur@flowerysong.com>
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'XLAB Steampunk'}
+
+DOCUMENTATION = '''
+module: cluster_role_info
+author:
+  - Paul Arthur (@flowerysong)
+  - Manca Bizjak (@mancabizjak)
+  - Aljaz Kosir (@aljazkosir)
+  - Tadej Borovsak (@tadeboro)
+short_description: Lists Sensu cluster roles
+description:
+  - For more information, refer to the Sensu documentation at
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+notes:
+  - Parameter C(auth.namespace) is ignored in this module.
+extends_documentation_fragment:
+  - sensu.sensu_go.base
+  - sensu.sensu_go.info
+'''
+
+EXAMPLES = '''
+- name: List all Sensu cluster roles
+  role_info:
+  register: result
+'''
+
+RETURN = '''
+roles:
+  description: list of Sensu cluster roles
+  returned: always
+  type: list
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    arguments, errors, utils,
+)
+
+
+def main():
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            arguments.get_spec("auth"),
+            name=dict()
+        ),
+    )
+
+    module.params['auth']['namespace'] = None  # Making sure we are not fallbacking to default
+    client = arguments.get_sensu_client(module.params["auth"])
+    if module.params["name"]:
+        path = "/clusterroles/{0}".format(module.params["name"])
+    else:
+        path = "/clusterroles"
+
+    try:
+        cluster_roles = utils.get(client, path)
+    except errors.Error as e:
+        module.fail_json(msg=str(e))
+
+    if module.params["name"]:
+        cluster_roles = [cluster_roles]
+    module.exit_json(changed=False, objects=cluster_roles)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/modules/molecule/cluster_role/Dockerfile.j2
+++ b/tests/integration/modules/molecule/cluster_role/Dockerfile.j2
@@ -1,0 +1,1 @@
+../shared/Dockerfile.j2

--- a/tests/integration/modules/molecule/cluster_role/molecule.yml
+++ b/tests/integration/modules/molecule/cluster_role/molecule.yml
@@ -1,0 +1,16 @@
+---
+scenario:
+  name: cluster_role
+platforms:
+  - name: latest
+    image: sensu/sensu:latest
+    command: &cmd >
+      sensu-backend start
+        --state-dir /var/lib/sensu/sensu-backend/etcd1
+        --log-level debug
+  - name: v5.13.1
+    image: sensu/sensu:5.13.1
+    command: *cmd
+  - name: v5.12.0
+    image: sensu/sensu:5.12.0
+    command: *cmd

--- a/tests/integration/modules/molecule/cluster_role/playbook.yml
+++ b/tests/integration/modules/molecule/cluster_role/playbook.yml
@@ -1,0 +1,208 @@
+---
+- name: Converge
+  collections:
+    - sensu.sensu_go
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Create a cluster role with missing required parameters
+      cluster_role:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "result.msg == 'state is present but all of the following are missing: rules'"
+
+    - name: Create a cluster role with empty rules
+      cluster_role:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role
+        rules: []
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "result.msg == 'state is present but all of the following are missing: rules'"
+
+    - name: Create a cluster role with invalid rule verbs
+      cluster_role:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role
+        rules:
+          - verbs:
+              - list
+              - do_something
+            resources:
+              - entities
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+
+    - name: Create a cluster role with minimal parameters
+      cluster_role:
+        auth:
+          url: http://localhost:8080
+        name: minimal_test_cluster_role
+        rules:
+          - verbs:
+              - get
+              - list
+            resources:
+              - entities
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.metadata.name == 'minimal_test_cluster_role'
+          - result.object.rules | length == 1
+          - result.object.rules.0.verbs | length == 2
+          - result.object.rules.0.verbs == ['get', 'list']
+          - result.object.rules.0.resources == ['entities']
+
+    - name: Check idempotence of cluster role creation with minimal parameters
+      cluster_role:
+        auth:
+          url: http://localhost:8080
+        name: minimal_test_cluster_role
+        rules:
+          - verbs:
+              - list
+              - get
+            resources:
+              - entities
+      register: result
+
+    - assert:
+        that: result is not changed
+
+    - name: Create a cluster role
+      cluster_role:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role
+        rules:
+          - verbs:
+              - list
+            resources:
+              - assets
+              - checks
+            resource_names:
+              - some_resource_1
+              - some_resource_2
+          - verbs:
+              - list
+              - get
+            resources:
+              - checks
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.metadata.name == 'test_cluster_role'
+          - result.object.rules | length == 2
+          - result.object.rules.0.verbs | length == 1
+          - result.object.rules.0.verbs == ['list']
+          - result.object.rules.0.resources == ['assets', 'checks']
+          - result.object.rules.0.resource_names == ['some_resource_1', 'some_resource_2']
+          - result.object.rules.1.verbs == ['list', 'get']
+          - result.object.rules.1.resources == ['checks']
+          - not result.object.rules.1.resource_names
+
+    - name: Check idempotence of cluster role creation
+      cluster_role:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role
+        rules:
+          - verbs:
+              - list
+            resources:
+              - checks
+              - assets
+            resource_names:
+              - some_resource_2
+              - some_resource_1
+          - verbs:
+              - get
+              - list
+            resources:
+              - checks
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Modify a cluster role
+      cluster_role:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role
+        rules:
+          - verbs:
+              - list
+            resources:
+              - assets
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.rules | length == 1
+          - result.object.rules.0.verbs == ['list']
+          - result.object.rules.0.resources == ['assets']
+          - not result.object.rules.0.resource_names
+
+    - name: Fetch all cluster roles
+      cluster_role_info:
+        auth:
+          url: http://localhost:8080
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 8 # There are 6 default cluster roles
+
+    - name: Fetch a specific cluster role
+      cluster_role_info:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 1
+          - result.objects.0.metadata.name == 'test_cluster_role'
+
+    - name: Delete a cluster role
+      cluster_role:
+        auth:
+          url: http://localhost:8080
+        state: absent
+        name: minimal_test_cluster_role
+      register: result
+
+    - name: Fetch all cluster roles after deletion of a cluster role
+      cluster_role_info:
+        auth:
+          url: http://localhost:8080
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 7 # There are 6 default cluster roles

--- a/tests/unit/module_utils/test_arguments.py
+++ b/tests/unit/module_utils/test_arguments.py
@@ -78,6 +78,20 @@ class TestGetMutationPayload:
             ),
         )
 
+    def test_namespace_is_none(self):
+        params = dict(
+            auth=dict(
+                namespace=None
+            ),
+            name="name",
+        )
+
+        assert arguments.get_mutation_payload(params) == dict(
+            metadata=dict(
+                name="name"
+            ),
+        )
+
     def test_labels(self):
         params = dict(
             auth=dict(

--- a/tests/unit/modules/test_cluster_role.py
+++ b/tests/unit/modules/test_cluster_role.py
@@ -1,0 +1,122 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    errors, utils
+)
+from ansible_collections.sensu.sensu_go.plugins.modules import cluster_role
+
+from .common.utils import (
+    AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args,
+)
+
+
+class TestClusterRole(ModuleTestCase):
+    def test_minimal_cluster_role_parameters(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.return_value = True, {}
+        set_module_args(
+            name='test_cluster_role',
+            rules=[
+                dict(
+                    verbs=[],
+                    resources=[]
+                ),
+            ]
+        )
+
+        with pytest.raises(AnsibleExitJson):
+            cluster_role.main()
+
+        state, _client, path, payload, check_mode, _compare = sync_mock.call_args[0]
+        assert state == 'present'
+        assert path == '/clusterroles/test_cluster_role'
+        assert payload == dict(
+            rules=[
+                dict(
+                    verbs=[],
+                    resources=[],
+                    resource_names=None,
+                )
+            ],
+            metadata=dict(
+                name='test_cluster_role',
+            ),
+        )
+        assert check_mode is False
+
+    def test_all_cluster_role_parameters(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.return_value = True, {}
+        set_module_args(
+            name='test_cluster_role',
+            state='present',
+            rules=[
+                dict(
+                    verbs=['get', 'list', 'create'],
+                    resources=['assets', 'entities'],
+                ),
+                dict(
+                    verbs=['list'],
+                    resources=['check'],
+                    resource_names=['my-check'],
+                )
+            ],
+        )
+
+        with pytest.raises(AnsibleExitJson):
+            cluster_role.main()
+
+        state, _client, path, payload, check_mode, _compare = sync_mock.call_args[0]
+        assert state == 'present'
+        assert path == '/clusterroles/test_cluster_role'
+        assert payload == dict(
+            metadata=dict(
+                name='test_cluster_role',
+            ),
+            rules=[
+                dict(
+                    verbs=['get', 'list', 'create'],
+                    resources=['assets', 'entities'],
+                    resource_names=None,
+                ),
+                dict(
+                    verbs=['list'],
+                    resources=['check'],
+                    resource_names=['my-check'],
+                )
+            ],
+        )
+
+    def test_failure(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.side_effect = errors.Error("Bad error")
+        set_module_args(
+            name='test_cluster_role',
+            rules=[
+                dict(
+                    verbs=[],
+                    resources=[],
+                )
+            ],
+        )
+        with pytest.raises(AnsibleFailJson):
+            cluster_role.main()
+
+    def test_failure_invalid_verb(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.side_effect = Exception("Validation should fail but didn't")
+        set_module_args(
+            name='test_cluster_role',
+            rules=[
+                dict(
+                    verbs=['list', 'invalid'],
+                    resources=[],
+                ),
+            ]
+        )
+
+        with pytest.raises(AnsibleFailJson):
+            cluster_role.main()

--- a/tests/unit/modules/test_cluster_role_info.py
+++ b/tests/unit/modules/test_cluster_role_info.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    errors, utils,
+)
+from ansible_collections.sensu.sensu_go.plugins.modules import cluster_role_info
+
+from .common.utils import (
+    AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args,
+)
+
+
+class TestClusterRoleInfo(ModuleTestCase):
+    def test_get_all_cluster_roles(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = [1, 2, 3]
+        set_module_args()
+
+        with pytest.raises(AnsibleExitJson) as context:
+            cluster_role_info.main()
+
+        _client, path = get_mock.call_args[0]
+        assert path == "/clusterroles"
+        assert context.value.args[0]["objects"] == [1, 2, 3]
+
+    def test_get_single_cluster_role(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = 1
+        set_module_args(name="test-cluster-role")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            cluster_role_info.main()
+
+        _client, path = get_mock.call_args[0]
+        assert path == "/clusterroles/test-cluster-role"
+        assert context.value.args[0]["objects"] == [1]
+
+    def test_failure(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.side_effect = errors.Error("Bad error")
+        set_module_args(name="sample-cluster-role")
+
+        with pytest.raises(AnsibleFailJson):
+            cluster_role_info.main()


### PR DESCRIPTION
This PR is a follow-up of https://github.com/sensu/sensu-go-ansible/pull/70. We add cluster role and cluster role info support as a new modules. Cluster roles adds support for `Cluster-wide resource types` in addition to namespaced resource types.