### PR TITLE
Custom comparator and params validation check for the role module

### DIFF
--- a/plugins/module_utils/role_utils.py
+++ b/plugins/module_utils/role_utils.py
@@ -7,6 +7,13 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+def validate_module_params(params):
+    if params['state'] == 'present':
+        if not params['rules']:
+            return 'state is present but all of the following are missing: rules'
+    return None
+
+
 def type_name_dict(obj_type, name):
     return {
         'type': obj_type,

--- a/plugins/modules/cluster_role.py
+++ b/plugins/modules/cluster_role.py
@@ -80,15 +80,6 @@ from ansible_collections.sensu.sensu_go.plugins.module_utils import (
 )
 
 
-def validate_module_params(module):
-    params = module.params
-    if params['state'] == 'present':
-        if not params['rules']:
-            module.fail_json(
-                msg='state is present but all of the following are missing: rules'
-            )
-
-
 def main():
     module = AnsibleModule(
         supports_check_mode=True,
@@ -115,7 +106,10 @@ def main():
         )
     )
 
-    validate_module_params(module)
+    msg = role_utils.validate_module_params(module.params)
+    if msg:
+        module.fail_json(msg=msg)
+
     module.params['auth']['namespace'] = None  # Making sure we are not fallbacking to default
     client = arguments.get_sensu_client(module.params["auth"])
     path = "/clusterroles/{0}".format(module.params["name"])

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -78,15 +78,6 @@ from ansible_collections.sensu.sensu_go.plugins.module_utils import (
 )
 
 
-def validate_module_params(module):
-    params = module.params
-    if params['state'] == 'present':
-        if not params['rules']:
-            module.fail_json(
-                msg='state is present but all of the following are missing: rules'
-            )
-
-
 def main():
     module = AnsibleModule(
         supports_check_mode=True,
@@ -113,7 +104,10 @@ def main():
         )
     )
 
-    validate_module_params(module)
+    msg = role_utils.validate_module_params(module.params)
+    if msg:
+        module.fail_json(msg=msg)
+
     client = arguments.get_sensu_client(module.params["auth"])
     path = "/roles/{0}".format(module.params["name"])
     payload = arguments.get_mutation_payload(

--- a/tests/integration/modules/molecule/role/playbook.yml
+++ b/tests/integration/modules/molecule/role/playbook.yml
@@ -18,6 +18,20 @@
           - result is failed
           - "result.msg == 'state is present but all of the following are missing: rules'"
 
+    - name: Create a role with empty rules
+      role:
+        auth:
+          url: http://localhost:8080
+        name: test_role
+        rules: []
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "result.msg == 'state is present but all of the following are missing: rules'"
+
     - name: Create a role with invalid rule verbs
       role:
         auth:
@@ -28,7 +42,7 @@
               - list
               - do_something
             resources:
-              - entity
+              - entities
       ignore_errors: true
       register: result
 
@@ -46,7 +60,7 @@
               - get
               - list
             resources:
-              - entity
+              - entities
       register: result
 
     - assert:
@@ -56,7 +70,7 @@
           - result.object.rules | length == 1
           - result.object.rules.0.verbs | length == 2
           - result.object.rules.0.verbs == ['get', 'list']
-          - result.object.rules.0.resources == ['entity']
+          - result.object.rules.0.resources == ['entities']
 
     - name: Check idempotence of role creation with minimal parameters
       role:
@@ -65,10 +79,10 @@
         name: minimal_test_role
         rules:
           - verbs:
-              - get
               - list
+              - get
             resources:
-              - entity
+              - entities
       register: result
 
     - assert:
@@ -83,8 +97,8 @@
           - verbs:
               - list
             resources:
-              - asset
-              - check
+              - assets
+              - checks
             resource_names:
               - some_resource_1
               - some_resource_2
@@ -92,7 +106,7 @@
               - list
               - get
             resources:
-              - check
+              - checks
       register: result
 
     - assert:
@@ -102,10 +116,10 @@
           - result.object.rules | length == 2
           - result.object.rules.0.verbs | length == 1
           - result.object.rules.0.verbs == ['list']
-          - result.object.rules.0.resources == ['asset', 'check']
+          - result.object.rules.0.resources == ['assets', 'checks']
           - result.object.rules.0.resource_names == ['some_resource_1', 'some_resource_2']
           - result.object.rules.1.verbs == ['list', 'get']
-          - result.object.rules.1.resources == ['check']
+          - result.object.rules.1.resources == ['checks']
           - not result.object.rules.1.resource_names
 
     - name: Check idempotence of role creation
@@ -117,16 +131,16 @@
           - verbs:
               - list
             resources:
-              - asset
-              - check
+              - checks
+              - assets
             resource_names:
-              - some_resource_1
               - some_resource_2
+              - some_resource_1
           - verbs:
-              - list
               - get
+              - list
             resources:
-              - check
+              - checks
       register: result
 
     - assert:
@@ -142,7 +156,7 @@
           - verbs:
               - list
             resources:
-              - asset
+              - assets
       register: result
 
     - assert:
@@ -150,7 +164,7 @@
           - result is changed
           - result.object.rules | length == 1
           - result.object.rules.0.verbs == ['list']
-          - result.object.rules.0.resources == ['asset']
+          - result.object.rules.0.resources == ['assets']
           - not result.object.rules.0.resource_names
 
     - name: Fetch all roles

--- a/tests/unit/modules/test_role.py
+++ b/tests/unit/modules/test_role.py
@@ -30,7 +30,7 @@ class TestRole(ModuleTestCase):
         with pytest.raises(AnsibleExitJson):
             role.main()
 
-        state, _client, path, payload, check_mode = sync_mock.call_args[0]
+        state, _client, path, payload, check_mode, _compare = sync_mock.call_args[0]
         assert state == 'present'
         assert path == '/roles/test_role'
         assert payload == dict(
@@ -70,7 +70,7 @@ class TestRole(ModuleTestCase):
         with pytest.raises(AnsibleExitJson):
             role.main()
 
-        state, _client, path, payload, check_mode = sync_mock.call_args[0]
+        state, _client, path, payload, check_mode, _compare = sync_mock.call_args[0]
         assert state == 'present'
         assert path == '/roles/test_role'
         assert payload == dict(
@@ -118,6 +118,17 @@ class TestRole(ModuleTestCase):
                     resources=[],
                 ),
             ]
+        )
+
+        with pytest.raises(AnsibleFailJson):
+            role.main()
+
+    def test_failure_empty_rules(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.side_effect = Exception("Validation should fail but didn't")
+        set_module_args(
+            name='test_role',
+            rules=[]
         )
 
         with pytest.raises(AnsibleFailJson):


### PR DESCRIPTION
This PR includes a couple of fixes and minor updates in the `role` module, to bring it in sync with `cluster_role`:
* it adds a validation check to ensure `rules` parameter is provided and non-empty, same as in `cluster_role`*;
* it makes use of custom comparator provided by `role_utils`, to allow determination of roles' equality when `verbs`, `resources` or `resource_names` are equivalent but ordered differently.
* iz pluralizes resource names in integration tests so that they are aligned with valid Sensu resource types.

*Just thinking, would it make sense to move this validation to `role_utils` at some point?