### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Bug description**
+A clear and concise description of what the issue is.
+
+**How to reproduce the bug**
+1. Run the command `ansible-playbook -i inv ...`.
+
+**If applicable, content of the files used in commands from the previous step**
+For example, `inv` file from previous sample could contain:
+```
+[mygroup]
+10.5.126.31
+```
+
+**Expected result**
+A clear and concise description of what you expected to happen.
+
+**Actual result**
+A clear and concise description of what actually happened. Make sure you
+include any error messages, since they usually offer vital clues to the
+bug-fixing process.
+
+
+**Component versions**
+ - Ansible Version [e.g. 2.9.0]
+ - Sensu Go Collection Version [e.g. 0.7.5]
+ - Sensu Go Backend Version [e.g. 5.14.1]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Currently, people reporting bugs have no guidance whatsoever on how to structure a bug report. Adding an issue template should fill in this void in our processes around the project management.