### PR TITLE
Protected access to backend and agent configuration files

### DIFF
--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -9,6 +9,10 @@
   template:
     src: agent.yml.j2
     dest: /etc/sensu/agent.yml
+    # Keep this in sync with what the agent service is running as from packager
+    owner: sensu
+    group: sensu
+    mode: '0600'
   notify: Restart agent
   tags: [configure_agent]
 

--- a/roles/backend/tasks/main.yml
+++ b/roles/backend/tasks/main.yml
@@ -9,6 +9,10 @@
   template:
     src: backend.yml.j2
     dest: /etc/sensu/backend.yml
+    # Keep this in sync with what the backend service is running as from packager
+    owner: sensu
+    group: sensu
+    mode: '0600'
   notify: Restart backend
   tags: [configure_backend]
 

--- a/tests/integration/molecule/role_agent_default/playbook.yml
+++ b/tests/integration/molecule/role_agent_default/playbook.yml
@@ -19,6 +19,9 @@
     - assert:
         that:
           - result.stat.exists
+          - result.stat.mode == '0600'
+          - result.stat.pw_name == 'sensu'
+          - result.stat.gr_name == 'sensu'
 
     - name: Confirm default configuration settings
       lineinfile:

--- a/tests/integration/molecule/role_agent_default/playbook.yml
+++ b/tests/integration/molecule/role_agent_default/playbook.yml
@@ -8,6 +8,8 @@
   hosts: agents
   vars:
     agent_yml: /etc/sensu/agent.yml
+  tags:
+    - configure_agent
   tasks:
     - name: Agent configuration must exist
       stat:
@@ -39,8 +41,6 @@
     agent_config:
       backend-url:
         - "ws://0.0.0.0:4321"
-  tags:
-    - configure_agent
   become: yes
   roles:
     - role: sensu.sensu_go.agent
@@ -49,6 +49,8 @@
   hosts: agents
   vars:
     agent_yml: /etc/sensu/agent.yml
+  tags:
+    - configure_agent
   tasks:
     - name: Confirm overloaded variable sets
       lineinfile:
@@ -117,8 +119,6 @@
         - /dev/sda2
         - "-r"
       enable_env: false
-  tags:
-    - configure_agent
   become: yes
   roles:
     - role: sensu.sensu_go.agent
@@ -127,6 +127,8 @@
   hosts: agents
   vars:
     agent_yml: /etc/sensu/agent.yml
+  tags:
+    - configure_agent
   tasks:
     - name: Confirm full configuration settings
       lineinfile:

--- a/tests/integration/molecule/role_backend_default/playbook.yml
+++ b/tests/integration/molecule/role_backend_default/playbook.yml
@@ -8,6 +8,8 @@
   hosts: backends
   vars:
     backend_yml: /etc/sensu/backend.yml
+  tags:
+    - configure_backend
   tasks:
     - name: Backend configuration must exist
       stat:
@@ -37,8 +39,6 @@
       debug: no
       log-level: debug
       api-listen-address: "[::]:4430"
-  tags:
-    - configure_backend
   become: yes
   roles:
     - role: sensu.sensu_go.backend
@@ -47,6 +47,8 @@
   hosts: backends
   vars:
     backend_yml: /etc/sensu/backend.yml
+  tags:
+    - configure_backend
   tasks:
     - name: Confirm optional configuration settings
       lineinfile:
@@ -79,8 +81,6 @@
       etcd-initial-advertise-peer-urls:
         - https://10.10.0.1:2380
         - https://10.20.0.1:2380
-  tags:
-    - configure_backend
   become: yes
   roles:
     - role: sensu.sensu_go.backend
@@ -89,6 +89,8 @@
   hosts: backends
   vars:
     backend_yml: /etc/sensu/backend.yml
+  tags:
+    - configure_backend
   tasks:
     - name: Confirm full configuration settings
       lineinfile:

--- a/tests/integration/molecule/role_backend_default/playbook.yml
+++ b/tests/integration/molecule/role_backend_default/playbook.yml
@@ -19,6 +19,9 @@
     - assert:
         that:
           - result.stat.exists
+          - result.stat.mode == '0600'
+          - result.stat.pw_name == 'sensu'
+          - result.stat.gr_name == 'sensu'
 
     - name: Confirm default configuration settings
       lineinfile:


### PR DESCRIPTION
To address #95, we added the group and user ownership of the `/etc/sensu/backend.yml` and `/etc/sensu/agent.yml` files. We also set it to only be accessible to the `sensu:sensu` user and group.