### PR TITLE
Update cluster_role_binding and cluster_role_binding_info modules

### DIFF
--- a/plugins/module_utils/role_utils.py
+++ b/plugins/module_utils/role_utils.py
@@ -14,6 +14,12 @@ def validate_module_params(params):
     return None
 
 
+def validate_binding_module_params(params):
+    if params["state"] == "present":
+        if not (params["users"] or params["groups"]):
+            return 'missing required parameters: users or groups'
+
+
 def type_name_dict(obj_type, name):
     return {
         'type': obj_type,

--- a/plugins/modules/cluster_role_binding.py
+++ b/plugins/modules/cluster_role_binding.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Paul Arthur <paul.arthur@flowerysong.com>
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'XLAB Steampunk'}
+
+DOCUMENTATION = '''
+module: cluster_role_binding
+author:
+ - Paul Arthur (@flowerysong)
+ - Manca Bizjak (@mancabizjak)
+ - Aljaz Kosir (@aljazkosir)
+ - Tadej Borovsak (@tadeboro)
+short_description: Manages Sensu cluster role bindings
+description:
+  - For more information, refer to the Sensu documentation at
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+extends_documentation_fragment:
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+notes:
+  - Parameter C(auth.namespace) is ignored in this module.
+options:
+  cluster_role:
+    description:
+      - Name of the cluster role
+    type: str
+  users:
+    description:
+      - List of users to bind to the cluster role
+      - Note that at least one of 'users' and 'groups' must be
+        specified when creating a cluster role binding.
+    type: list
+  groups:
+    description:
+      - List of groups to bind to the cluster role
+      - Note that at least one of 'users' and 'groups' must be
+        specified when creating a cluster role binding.
+    type: list
+'''
+
+EXAMPLES = '''
+- name: Create a cluster role binding
+  cluster_role_binding:
+    name: all-cluster-admins
+    cluster_role: cluster-admin
+    groups:
+        - cluster-admins
+    users:
+      - alice
+'''
+
+RETURN = '''
+object:
+    description: object representing Sensu cluster role binding
+    returned: success
+    type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    arguments, errors, utils, role_utils
+)
+
+
+def build_api_payload(params):
+    payload = arguments.get_mutation_payload(params)
+    payload["subjects"] = role_utils.build_subjects(params["groups"], params["users"])
+    payload["role_ref"] = role_utils.type_name_dict("ClusterRole", params["cluster_role"])
+
+    return payload
+
+
+def main():
+    required_if = [
+        ("state", "present", ["cluster_role"])
+    ]
+    module = AnsibleModule(
+        required_if=required_if,
+        supports_check_mode=True,
+        argument_spec=dict(
+            arguments.get_spec("auth", "name", "state"),
+            cluster_role=dict(),
+            users=dict(
+                type="list",
+            ),
+            groups=dict(
+                type="list",
+            ),
+        )
+    )
+
+    msg = role_utils.validate_binding_module_params(module.params)
+    if msg:
+        module.fail_json(msg=msg)
+
+    module.params['auth']['namespace'] = None  # Making sure we are not fallbacking to default
+    client = arguments.get_sensu_client(module.params["auth"])
+    path = "/clusterrolebindings/{0}".format(module.params["name"])
+    payload = build_api_payload(module.params)
+
+    try:
+        changed, cluster_role_binding = utils.sync(
+            module.params["state"], client, path, payload, module.check_mode, role_utils.do_role_bindings_differ
+        )
+        module.exit_json(changed=changed, object=cluster_role_binding)
+    except errors.Error as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/cluster_role_binding_info.py
+++ b/plugins/modules/cluster_role_binding_info.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Paul Arthur <paul.arthur@flowerysong.com>
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'XLAB Steampunk'}
+
+DOCUMENTATION = '''
+module: cluster_role_binding_info
+author:
+  - Paul Arthur (@flowerysong)
+  - Manca Bizjak (@mancabizjak)
+  - Aljaz Kosir (@aljazkosir)
+  - Tadej Borovsak (@tadeboro)
+short_description: Lists Sensu cluster role bindings
+description:
+  - For more information, refer to the Sensu documentation at
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+notes:
+  - Parameter C(auth.namespace) is ignored in this module.
+extends_documentation_fragment:
+  - sensu.sensu_go.base
+  - sensu.sensu_go.info
+'''
+
+EXAMPLES = '''
+- name: List all Sensu cluster role bindings
+  cluster_role_binding_info:
+  register: result
+'''
+
+RETURN = '''
+cluster_role_bindings:
+  description: list of Sensu cluster role bindings
+  returned: always
+  type: list
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    arguments, errors, utils,
+)
+
+
+def main():
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            arguments.get_spec("auth"),
+            name=dict()
+        )
+    )
+
+    module.params['auth']['namespace'] = None  # Making sure we are not fallbacking to default
+    client = arguments.get_sensu_client(module.params["auth"])
+    if module.params["name"]:
+        path = "/clusterrolebindings/{0}".format(module.params["name"])
+    else:
+        path = "/clusterrolebindings"
+
+    try:
+        cluster_role_bindings = utils.get(client, path)
+    except errors.Error as e:
+        module.fail_json(msg=str(e))
+
+    if module.params["name"]:
+        cluster_role_bindings = [cluster_role_bindings]
+    module.exit_json(changed=False, objects=cluster_role_bindings)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/role_binding.py
+++ b/plugins/modules/role_binding.py
@@ -72,15 +72,6 @@ from ansible_collections.sensu.sensu_go.plugins.module_utils import (
 )
 
 
-def validate_module_params(module):
-    params = module.params
-    if params["state"] == "present":
-        if not (params["users"] or params["groups"]):
-            module.fail_json(
-                msg="missing required parameters: users or groups"
-            )
-
-
 def build_api_payload(params):
     payload = arguments.get_mutation_payload(params)
     payload["subjects"] = role_utils.build_subjects(params["groups"], params["users"])
@@ -108,7 +99,10 @@ def main():
         )
     )
 
-    validate_module_params(module)
+    msg = role_utils.validate_binding_module_params(module.params)
+    if msg:
+        module.fail_json(msg=msg)
+
     client = arguments.get_sensu_client(module.params["auth"])
     path = "/rolebindings/{0}".format(module.params["name"])
     payload = build_api_payload(module.params)

--- a/tests/integration/molecule/module_cluster_role_binding/playbook.yml
+++ b/tests/integration/molecule/module_cluster_role_binding/playbook.yml
@@ -1,0 +1,183 @@
+---
+- name: Converge
+  collections:
+    - sensu.sensu_go
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Create a cluster role binding with missing required parameters
+      cluster_role_binding:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role_binding
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "result.msg == 'state is present but all of the following are missing: cluster_role'"
+
+    - name: Create a cluster role binding without providing users or groups
+      cluster_role_binding:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role_binding
+        cluster_role: test_cluster_role
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "result.msg == 'missing required parameters: users or groups'"
+
+    - name: Create a cluster role binding with minimal parameters (users only)
+      cluster_role_binding:
+        auth:
+          url: http://localhost:8080
+        name: minimal_test_cluster_role_binding_users
+        cluster_role: test_cluster_role
+        users:
+          - test_user
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.metadata.name == 'minimal_test_cluster_role_binding_users'
+          - result.object.role_ref.name == 'test_cluster_role'
+          - result.object.subjects | length == 1
+          - result.object.subjects.0.name == 'test_user'
+          - result.object.subjects.0.type == 'User'
+
+    - name: Create a cluster role binding with minimal parameters (groups only)
+      cluster_role_binding:
+        auth:
+          url: http://localhost:8080
+        name: minimal_test_cluster_role_binding_groups
+        cluster_role: test_cluster_role
+        groups:
+          - test_group_1
+          - test_group_2
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.metadata.name == 'minimal_test_cluster_role_binding_groups'
+          - result.object.role_ref.name == 'test_cluster_role'
+          - result.object.subjects | length == 2
+
+    - name: Check idempotence of cluster role binding creation with minimal parameters
+      cluster_role_binding:
+        auth:
+          url: http://localhost:8080
+        name: minimal_test_cluster_role_binding_groups
+        cluster_role: test_cluster_role
+        groups:
+          - test_group_2
+          - test_group_1
+      register: result
+
+    - assert:
+        that: result is not changed
+
+    - name: Create a cluster role binding
+      cluster_role_binding:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role_binding
+        cluster_role: test_cluster_role
+        users:
+          - test_user_1
+          - test_user_2
+        groups:
+          - test_group_1
+          - test_group_2
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.metadata.name == 'test_cluster_role_binding'
+          - result.object.role_ref.name == 'test_cluster_role'
+          - result.object.subjects | length == 4
+
+    - name: Check idempotence of cluster role binding creation
+      cluster_role_binding:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role_binding
+        cluster_role: test_cluster_role
+        users:
+          - test_user_2
+          - test_user_1
+        groups:
+          - test_group_2
+          - test_group_1
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Modify a cluster role binding
+      cluster_role_binding:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role_binding
+        cluster_role: another_cluster_role
+        users:
+        groups:
+          - group_1
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.metadata.name == 'test_cluster_role_binding'
+          - result.object.role_ref.name == 'another_cluster_role'
+          - result.object.subjects | length == 1
+          - result.object.subjects.0.name == 'group_1'
+          - result.object.subjects.0.type == 'Group'
+
+    - name: Fetch all cluster role bindings
+      cluster_role_binding_info:
+        auth:
+          url: http://localhost:8080
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 6 # There are 3 pre-existing cluster role bindings by default
+
+    - name: Fetch a specific cluster role binding
+      cluster_role_binding_info:
+        auth:
+          url: http://localhost:8080
+        name: test_cluster_role_binding
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 1
+          - result.objects.0.metadata.name == 'test_cluster_role_binding'
+
+    - name: Delete a cluster role binding
+      cluster_role_binding:
+        auth:
+          url: http://localhost:8080
+        state: absent
+        name: test_cluster_role_binding
+      register: result
+
+    - name: Fetch all cluster roles bindings after deletion
+      cluster_role_binding_info:
+        auth:
+          url: http://localhost:8080
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 5 # There are 3 pre-existing cluster role bindings by default

--- a/tests/integration/scenario.times
+++ b/tests/integration/scenario.times
@@ -1,6 +1,7 @@
 molecule/module_asset 66.96
 molecule/module_check 76.34
 molecule/module_cluster_role 80.00
+molecule/module_cluster_role_binding 78.40
 molecule/module_entity 72.09
 molecule/module_filter 76.15
 molecule/module_handler_set 65.25

--- a/tests/unit/modules/test_cluster_role_binding.py
+++ b/tests/unit/modules/test_cluster_role_binding.py
@@ -1,0 +1,146 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    errors, utils,
+)
+from ansible_collections.sensu.sensu_go.plugins.modules import cluster_role_binding
+
+from .common.utils import (
+    AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args,
+)
+
+
+class TestClusterRoleBinding(ModuleTestCase):
+    def test_minimal_cluster_role_binding_parameters_users(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.return_value = True, {}
+        set_module_args(
+            name='test_cluster_role_binding',
+            cluster_role='test_cluster_role',
+            users=['test_user'],
+        )
+
+        with pytest.raises(AnsibleExitJson):
+            cluster_role_binding.main()
+
+        state, _client, path, payload, check_mode, _compare = sync_mock.call_args[0]
+        assert state == 'present'
+        assert path == '/clusterrolebindings/test_cluster_role_binding'
+        assert payload == dict(
+            role_ref=dict(
+                name='test_cluster_role',
+                type='ClusterRole',
+            ),
+            subjects=[
+                dict(
+                    name='test_user',
+                    type='User',
+                ),
+            ],
+            metadata=dict(
+                name='test_cluster_role_binding',
+            ),
+        )
+        assert check_mode is False
+
+    def test_minimal_cluster_role_binding_parameters_groups(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.return_value = True, {}
+        set_module_args(
+            name='test_cluster_role_binding',
+            cluster_role='test_cluster_role',
+            groups=['test_group'],
+        )
+
+        with pytest.raises(AnsibleExitJson):
+            cluster_role_binding.main()
+
+        state, _client, path, payload, check_mode, _compare = sync_mock.call_args[0]
+        assert state == 'present'
+        assert path == '/clusterrolebindings/test_cluster_role_binding'
+        assert payload == dict(
+            role_ref=dict(
+                name='test_cluster_role',
+                type='ClusterRole',
+            ),
+            subjects=[
+                dict(
+                    name='test_group',
+                    type='Group',
+                ),
+            ],
+            metadata=dict(
+                name='test_cluster_role_binding',
+            ),
+        )
+        assert check_mode is False
+
+    def test_all_cluster_role_binding_parameters(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.return_value = True, {}
+        set_module_args(
+            name='test_cluster_role_binding',
+            cluster_role='test_cluster_role',
+            users=['user_1', 'user_2'],
+            groups=['group_1', 'group_2'],
+        )
+
+        with pytest.raises(AnsibleExitJson):
+            cluster_role_binding.main()
+
+        state, _client, path, payload, check_mode, _compare = sync_mock.call_args[0]
+        assert state == 'present'
+        assert path == '/clusterrolebindings/test_cluster_role_binding'
+        assert payload == dict(
+            metadata=dict(
+                name='test_cluster_role_binding',
+            ),
+            role_ref=dict(
+                name='test_cluster_role',
+                type='ClusterRole',
+            ),
+            subjects=[
+                dict(
+                    name='group_1',
+                    type='Group',
+                ),
+                dict(
+                    name='group_2',
+                    type='Group',
+                ),
+                dict(
+                    name='user_1',
+                    type='User',
+                ),
+                dict(
+                    name='user_2',
+                    type='User',
+                ),
+            ]
+        )
+        assert check_mode is False
+
+    def test_failure(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.side_effect = errors.Error('Bad error')
+        set_module_args(
+            name='test_cluster_role_binding',
+            cluster_role='test_cluster_role',
+            users=['test_user'],
+        )
+        with pytest.raises(AnsibleFailJson):
+            cluster_role_binding.main()
+
+    def test_failure_missing_groups_or_users(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.side_effect = Exception("Validation should fail but didn't")
+        set_module_args(
+            name='test_cluster_role_binding',
+            cluster_role='test_cluster_role',
+        )
+
+        with pytest.raises(AnsibleFailJson):
+            cluster_role_binding.main()

--- a/tests/unit/modules/test_cluster_role_binding_info.py
+++ b/tests/unit/modules/test_cluster_role_binding_info.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    errors, utils,
+)
+from ansible_collections.sensu.sensu_go.plugins.modules import cluster_role_binding_info
+
+from .common.utils import (
+    AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args,
+)
+
+
+class TestClusterRoleBindingInfo(ModuleTestCase):
+    def test_get_all_cluster_role_bindings(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = [1, 2, 3]
+        set_module_args()
+
+        with pytest.raises(AnsibleExitJson) as context:
+            cluster_role_binding_info.main()
+
+        _client, path = get_mock.call_args[0]
+        assert path == "/clusterrolebindings"
+        assert context.value.args[0]["objects"] == [1, 2, 3]
+
+    def test_get_single_cluster_role_binding(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = 1
+        set_module_args(name="test-cluster-role-binding")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            cluster_role_binding_info.main()
+
+        _client, path = get_mock.call_args[0]
+        assert path == "/clusterrolebindings/test-cluster-role-binding"
+        assert context.value.args[0]["objects"] == [1]
+
+    def test_failure(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.side_effect = errors.Error("Bad error")
+        set_module_args(name="sample-cluster-role-binding")
+
+        with pytest.raises(AnsibleFailJson):
+            cluster_role_binding_info.main()


### PR DESCRIPTION
This commit applies the new module structure to `cluster_role_binding` and `cluster_role_binding_info` modules. Cluster role bindings allow assignment of cluster roles to users and groups.

To avoid duplication of module params validation code (which is exactly the same for both `role_binding` and `cluster_role_binding` modules), I added a slightly modified version of the validator previously in `role_binding.py` and moved it to common `utils/role_utils`, where it can be used by both modules.