### PR TITLE
Disable testing on latest stable Sensu Go

### DIFF
--- a/tests/integration/base.yml
+++ b/tests/integration/base.yml
@@ -63,7 +63,7 @@ verifier:
     enabled: false
 platforms:
   - name: latest
-    image: sensu/sensu:latest
+    image: sensu/sensu:5.14.1
     command: &cmd >
       sensu-backend start
         --state-dir /var/lib/sensu/sensu-backend/etcd1


### PR DESCRIPTION
Because Sensu Go 5.15 contains a bug that crashes our test suite, we temporarily disabled the testing on that version.

Once the 5.15.1 is out, we should start testing this again.