### PR TITLE
Update asset module API to support multiple-build assets

### DIFF
--- a/tests/integration/molecule/module_asset/playbook.yml
+++ b/tests/integration/molecule/module_asset/playbook.yml
@@ -5,19 +5,89 @@
   hosts: all
   gather_facts: no
   tasks:
+    - name: Create an asset with missing required parameters
+      asset:
+        auth:
+          url: http://localhost:8080
+        name: asset
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "result.msg == 'state is present but all of the following are missing: builds'"
+
+    - name: Create an asset with empty builds
+      asset:
+        auth:
+          url: http://localhost:8080
+        name: asset
+        builds:
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "result.msg == 'builds must include at least one element'"
+
+    - name: Create an asset with missing parameters for build
+      asset:
+        auth:
+          url: http://localhost:8080
+        name: asset
+        builds:
+          - url: http://assets.bonsai.sensu.io/asset
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "result.msg == 'missing required arguments: sha512 found in builds'"
+
+    - name: Create an asset with minimal parameters
+      asset:
+        auth:
+          url: http://localhost:8080
+        name: minimal_asset
+        builds:
+          - url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
+            sha512: 518e7c17cf670393045bff4af318e1d35955bfde166e9ceec2b469109252f79043ed133241c4dc96501b6636a1ec5e008ea9ce055d1609865635d4f004d7187b
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.builds | length == 1
+          - result.object.builds.0.url == 'https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz'
+          - result.object.builds.0.sha512 == '518e7c17cf670393045bff4af318e1d35955bfde166e9ceec2b469109252f79043ed133241c4dc96501b6636a1ec5e008ea9ce055d1609865635d4f004d7187b'
+          - result.object.builds.0.filters == None
+          - result.object.builds.0.headers == None
+
     - name: Create an asset
       asset:
         auth:
           url: http://localhost:8080
         name: asset
-        url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
-        sha512: 518e7c17cf670393045bff4af318e1d35955bfde166e9ceec2b469109252f79043ed133241c4dc96501b6636a1ec5e008ea9ce055d1609865635d4f004d7187b
-        filters:
-          - "entity.system.os == 'linux'"
-          - "entity.system.arch == 'amd64'"
-          - "entity.system.platform == 'rhel'"
-        headers:
-          Sensu-Blivet: foo
+        builds:
+          - url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
+            sha512: 518e7c17cf670393045bff4af318e1d35955bfde166e9ceec2b469109252f79043ed133241c4dc96501b6636a1ec5e008ea9ce055d1609865635d4f004d7187b
+            filters:
+              - entity.system.os == 'linux'
+              - entity.system.arch == 'amd64'
+              - entity.system.platform == 'rhel'
+            headers:
+              Sensu-Blivet: foo
+          - url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_alpine_linux_amd64.tar.gz
+            sha512: b2da25ecd7642e6de41fde37d674fe19dcb6ee3d680e145e32289f7cfc352e6b5f9413ee9b701d61faeaa47b399aa30b25885dbc1ca432c4061c8823774c28f3
+            filters:
+              - entity.system.os == 'linux'
+              - entity.system.arch == 'amd64'
+              - entity.system.platform == 'alpine'
+            headers:
+              Sensu-Blivet: bar
         annotations:
           sensio.io.bonsai.url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
           sensio.io.bonsai.tier: Community
@@ -28,25 +98,32 @@
     - assert:
         that:
           - result is changed
-          - result.object.url == 'https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz'
-          - result.object.sha512 == '518e7c17cf670393045bff4af318e1d35955bfde166e9ceec2b469109252f79043ed133241c4dc96501b6636a1ec5e008ea9ce055d1609865635d4f004d7187b'
-          - result.object.headers['Sensu-Blivet'] == "foo"
-          - result.object.filters == ["entity.system.os == 'linux'", "entity.system.arch == 'amd64'", "entity.system.platform == 'rhel'"]
           - result.object.metadata.name == 'asset'
+          - result.object.builds | length == 2
+          - result.object.metadata.annotations | dict2items | length == 4
 
     - name: Test asset creation idempotence
       asset:
         auth:
           url: http://localhost:8080
         name: asset
-        url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
-        sha512: 518e7c17cf670393045bff4af318e1d35955bfde166e9ceec2b469109252f79043ed133241c4dc96501b6636a1ec5e008ea9ce055d1609865635d4f004d7187b
-        filters:
-          - "entity.system.os == 'linux'"
-          - "entity.system.arch == 'amd64'"
-          - "entity.system.platform == 'rhel'"
-        headers:
-          Sensu-Blivet: foo
+        builds:
+          - url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_alpine_linux_amd64.tar.gz
+            sha512: b2da25ecd7642e6de41fde37d674fe19dcb6ee3d680e145e32289f7cfc352e6b5f9413ee9b701d61faeaa47b399aa30b25885dbc1ca432c4061c8823774c28f3
+            filters:
+              - entity.system.platform == 'alpine'
+              - entity.system.os == 'linux'
+              - entity.system.arch == 'amd64'
+            headers:
+              Sensu-Blivet: bar
+          - url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
+            sha512: 518e7c17cf670393045bff4af318e1d35955bfde166e9ceec2b469109252f79043ed133241c4dc96501b6636a1ec5e008ea9ce055d1609865635d4f004d7187b
+            filters:
+              - entity.system.arch == 'amd64'
+              - entity.system.platform == 'rhel'
+              - entity.system.os == 'linux'
+            headers:
+              Sensu-Blivet: foo
         annotations:
           sensio.io.bonsai.url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
           sensio.io.bonsai.tier: Community
@@ -57,13 +134,14 @@
     - assert:
         that: result is not changed
 
-    - name: Modify asset
+    - name: Modify an asset
       asset:
         auth:
           url: http://localhost:8080
         name: asset
-        url: https://assets.bonsai.sensu.io/73a6f8b6f56672630d83ec21676f9a6251094475/sensu-plugins-disk-checks_5.0.0_centos_linux_amd64.tar.gz
-        sha512: 0ce9d52b270b77f4cab754e55732ae002228201d0bd01a89b954a0655b88c1ee6546e2f82cfd1eec04689af90ad940cde128e8867912d9e415f4a58d7fdcdadf
+        builds:
+          - url: https://assets.bonsai.sensu.io/73a6f8b6f56672630d83ec21676f9a6251094475/sensu-plugins-disk-checks_5.0.0_centos_linux_amd64.tar.gz
+            sha512: 0ce9d52b270b77f4cab754e55732ae002228201d0bd01a89b954a0655b88c1ee6546e2f82cfd1eec04689af90ad940cde128e8867912d9e415f4a58d7fdcdadf
         annotations:
           sensio.io.bonsai.url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
           sensio.io.bonsai.tier: Community
@@ -73,27 +151,12 @@
     - assert:
         that:
           - result is changed
-          - not result.object.headers
-          - not result.object.filters
-          - result.object.sha512 == '0ce9d52b270b77f4cab754e55732ae002228201d0bd01a89b954a0655b88c1ee6546e2f82cfd1eec04689af90ad940cde128e8867912d9e415f4a58d7fdcdadf'
+          - result.object.builds | length == 1
+          - result.object.builds.0.sha512 == '0ce9d52b270b77f4cab754e55732ae002228201d0bd01a89b954a0655b88c1ee6546e2f82cfd1eec04689af90ad940cde128e8867912d9e415f4a58d7fdcdadf'
+          - not result.object.builds.0.headers
+          - not result.object.builds.0.filters
+          - result.object.metadata.annotations | dict2items | length == 3
           - "'sensu.io.bonsai.tags' not in result.object.metadata.annotations"
-
-    - name: Create a second asset
-      asset:
-        auth:
-          url: http://localhost:8080
-        name: asset2
-        url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
-        sha512: 518e7c17cf670393045bff4af318e1d35955bfde166e9ceec2b469109252f79043ed133241c4dc96501b6636a1ec5e008ea9ce055d1609865635d4f004d7187b
-        filters:
-          - "entity.system.os == 'linux'"
-          - "entity.system.arch == 'amd64'"
-          - "entity.system.platform == 'rhel'"
-        annotations:
-          sensio.io.bonsai.url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
-          sensio.io.bonsai.tier: Community
-          sensio.io.bonsai.version: 4.0.0
-          sensio.io.bonsai.tags: ruby-runtime-2.4.4
 
     - name: Fetch a specific asset
       asset_info:
@@ -118,14 +181,14 @@
           - result.objects | length == 2
           - result.objects.0.metadata.name == 'asset'
 
-    - name: Delete second asset
+    - name: Delete an asset
       asset:
         auth:
           url: http://localhost:8080
         name: asset2
         state: absent
 
-    - name: Fetch all assets
+    - name: Fetch all assets again after deletion
       asset_info:
         auth:
           url: http://localhost:8080
@@ -133,5 +196,5 @@
 
     - assert:
         that:
-          - result.objects | length == 1
+          - result.objects | length == 2
           - result.objects.0.metadata.name == 'asset'

--- a/tests/integration/scenario.times
+++ b/tests/integration/scenario.times
@@ -1,5 +1,5 @@
 molecule/module_tessen 48.77
-molecule/module_asset 66.96
+molecule/module_asset 76.96
 molecule/module_check 76.34
 molecule/module_cluster_role 80.00
 molecule/module_cluster_role_binding 78.40

--- a/tests/unit/modules/test_asset.py
+++ b/tests/unit/modules/test_asset.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 import pytest
@@ -13,25 +14,172 @@ from .common.utils import (
 )
 
 
+class TestDoDiffer:
+    def test_new_asset(self):
+        assert asset.do_differ(
+            None,
+            {
+                "name": "a",
+                "builds": [
+                    {
+                        "url": "http://abc.com",
+                        "sha512": "abc",
+                    }
+                ]
+            },
+        ) is True
+
+    def test_equal_assets_with_none_values(self):
+        assert asset.do_differ(
+            {
+                "name": "asset",
+                "builds": [
+                    {
+                        "sha512": "a",
+                        "url": "a",
+                        "filters": None
+                    },
+                ],
+            },
+            {
+                "name": "asset",
+                "builds": [
+                    {
+                        "sha512": "a",
+                        "url": "a",
+                        "headers": None,
+                    },
+                ],
+            },
+        ) is False
+
+    def test_equal_assets_with_different_build_content(self):
+        assert asset.do_differ(
+            {
+                "name": "asset",
+                "builds": [
+                    {
+                        "url": "http://abc.com",
+                        "sha512": "abc",
+                        "headers": {
+                            "foo": "bar",
+                            "bar": "foo",
+                        }
+                    },
+                    {
+                        "url": "http://def.com",
+                        "sha512": "def",
+                        "filters": ["d == d", "e == e"],
+                    },
+
+                ]
+            },
+            {
+                "name": "asset",
+                "builds": [
+                    {
+                        "url": "http://def.com",
+                        "sha512": "def",
+                        "filters": ["e == e", "d == d"],
+                    },
+                    {
+                        "url": "http://abc.com",
+                        "sha512": "abc",
+                        "headers": {
+                            "bar": "foo",
+                            "foo": "bar"
+                        }
+                    },
+                ]
+            },
+        ) is False
+
+    def test_updated_asset(self):
+        assert asset.do_differ(
+            {
+                "name": "asset",
+                "builds": [
+                    {
+                        "url": "http://abc.com",
+                        "sha512": "abc",
+                    }
+                ],
+                "annotations": {
+                    "foo": "bar",
+                }
+            },
+            {
+                "name": "asset",
+                "builds": [
+                    {
+                        "url": "http://def.com",
+                        "sha512": "abc",
+                    },
+                    {
+                        "url": "http://def.com",
+                        "sha512": "abc",
+                        "filters": ["abc == def"],
+                    }
+                ],
+            },
+        ) is True
+
+    def test_different_assets_with_same_builds(self):
+        assert asset.do_differ(
+            {
+                "name": "a",
+                "builds": [
+                    {
+                        "url": "http://abc.com",
+                        "sha512": "abc",
+                    }
+                ],
+                "annotations": {
+                    "foo": "bar",
+                }
+            },
+            {
+                "name": "b",
+                "builds": [
+                    {
+                        "url": "http://abc.com",
+                        "sha512": "abc",
+                    }
+                ],
+                "annotations": {
+                    "bar": "foo"
+                }
+            },
+        ) is True
+
+
 class TestAsset(ModuleTestCase):
     def test_minimal_asset_parameters(self, mocker):
         sync_mock = mocker.patch.object(utils, "sync")
         sync_mock.return_value = True, {}
         set_module_args(
             name="test_asset",
-            url="http://example.com/asset.tar.gz",
-            sha512="sha512String",
+            builds=[
+                dict(
+                    url="http://example.com/asset.tar.gz",
+                    sha512="sha512String",
+                ),
+            ]
         )
 
         with pytest.raises(AnsibleExitJson):
             asset.main()
 
-        state, _client, path, payload, check_mode = sync_mock.call_args[0]
+        state, _client, path, payload, check_mode, _do_differ = sync_mock.call_args[0]
         assert state == "present"
         assert path == "/assets/test_asset"
         assert payload == dict(
-            url="http://example.com/asset.tar.gz",
-            sha512="sha512String",
+            builds=[
+                dict(
+                    url="http://example.com/asset.tar.gz",
+                    sha512="sha512String",
+                ),
+            ],
             metadata=dict(
                 name="test_asset",
                 namespace="default",
@@ -44,11 +192,15 @@ class TestAsset(ModuleTestCase):
         sync_mock.return_value = True, {}
         set_module_args(
             name="test_asset",
-            state="absent",
-            url="http://example.com/asset.tar.gz",
-            sha512="sha512String",
-            filters=["a", "b", "c"],
-            headers={"header": "h"},
+            state="present",
+            builds=[
+                dict(
+                    url="http://example.com/asset.tar.gz",
+                    sha512="sha512String",
+                    filters=["a", "b", "c"],
+                    headers={"header": "h"},
+                ),
+            ],
             labels={"region": "us-west-1"},
             annotations={"playbook": 12345},
         )
@@ -56,14 +208,18 @@ class TestAsset(ModuleTestCase):
         with pytest.raises(AnsibleExitJson):
             asset.main()
 
-        state, _client, path, payload, check_mode = sync_mock.call_args[0]
-        assert state == "absent"
+        state, _client, path, payload, check_mode, _do_differ = sync_mock.call_args[0]
+        assert state == "present"
         assert path == "/assets/test_asset"
         assert payload == dict(
-            url="http://example.com/asset.tar.gz",
-            sha512="sha512String",
-            filters=["a", "b", "c"],
-            headers={"header": "h"},
+            builds=[
+                dict(
+                    url="http://example.com/asset.tar.gz",
+                    sha512="sha512String",
+                    filters=["a", "b", "c"],
+                    headers={"header": "h"},
+                )
+            ],
             metadata=dict(
                 name="test_asset",
                 namespace="default",
@@ -78,8 +234,24 @@ class TestAsset(ModuleTestCase):
         sync_mock.side_effect = errors.Error("Bad error")
         set_module_args(
             name="test_asset",
-            url="http://example.com/asset.tar.gz",
-            sha512="sha512String",
+            builds=[
+                dict(
+                    url="http://example.com/asset.tar.gz",
+                    sha512="sha512String",
+                )
+            ]
+
+        )
+
+        with pytest.raises(AnsibleFailJson):
+            asset.main()
+
+    def test_failure_empty_builds(self, mocker):
+        sync_mock = mocker.patch.object(utils, 'sync')
+        sync_mock.side_effect = Exception("Validation should fail but didn't")
+        set_module_args(
+            name="test_asset",
+            builds=[],
         )
 
         with pytest.raises(AnsibleFailJson):


### PR DESCRIPTION
This PR modifies the API of the asset module to allow creation of multiple-build assets.

 From now on `url`, `sha512`, `filters` and `headers` are no longer top-level arguments of the module, as all of these must/can be provided for individual builds. We introduce the `builds` argument that holds a list of builds with the same argument specification as the prevous single-build specification of the asset.

While the Sensu Go backend API allows top-level `filters` and `headers` when creating an asset in the latest version (`5.15` at the time of writing), this seems to be for backwards-compatibility with the older versions. In the module, we drop support for these in favor of per-build `headers` and `filters` only.


