### PR TITLE
Make sure agent role works without backends group

### DIFF
--- a/plugins/filter/backends.py
+++ b/plugins/filter/backends.py
@@ -15,8 +15,10 @@ def _format_backend(vars):
     return "{0}://{1}:{2}".format(protocol, vars["inventory_hostname"], 8081)
 
 
-def backends(hostvars, host_names):
-    return [_format_backend(hostvars[name]) for name in host_names]
+def backends(hostvars, groups):
+    return [
+        _format_backend(hostvars[name]) for name in groups.get("backends", [])
+    ]
 
 
 class FilterModule(object):

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # Related to /etc/sensu/backend.yml, see
 # https://docs.sensu.io/sensu-go/latest/reference/agent/#configuration-summary
-agent_backend_urls: "{{ hostvars | sensu.sensu_go.backends(groups.backends) }}"
+agent_backend_urls: "{{ hostvars | sensu.sensu_go.backends(groups) }}"
 agent_config:

--- a/tests/integration/molecule/role_agent_explicit_backend/molecule.yml
+++ b/tests/integration/molecule/role_agent_explicit_backend/molecule.yml
@@ -1,0 +1,10 @@
+---
+platforms:
+  - name: centos
+    image: xlabsi/centos:7
+    pre_build_image: true
+    pull: true
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/tests/integration/molecule/role_agent_explicit_backend/playbook.yml
+++ b/tests/integration/molecule/role_agent_explicit_backend/playbook.yml
@@ -1,0 +1,29 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - sensu.sensu_go.agent
+  vars:
+    agent_config:
+      backend-url:
+        - "ws://1.2.3.4:4321"
+
+  tasks:
+    - name: Agent configuration must exist
+      stat:
+        path: /etc/sensu/agent.yml
+      register: result
+
+    - assert:
+        that:
+          - result.stat.exists
+
+    - name: Confirm default configuration settings
+      lineinfile:
+        path: /etc/sensu/agent.yml
+        line: '- ws://1.2.3.4:4321'
+      register: result
+
+    - assert:
+        that:
+          - result is not changed

--- a/tests/integration/scenario.times
+++ b/tests/integration/scenario.times
@@ -18,6 +18,7 @@ molecule/module_socket_handler 103.61
 molecule/module_tessen 73.29
 molecule/module_user 97.89
 molecule/role_agent_default 228.46
+molecule/role_agent_explicit_backend 130.34
 molecule/role_agent_secured 120.17
 molecule/role_backend_default 176.20
 molecule/role_backend_secured 314.82

--- a/tests/unit/filter/test_backends.py
+++ b/tests/unit/filter/test_backends.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.sensu.sensu_go.plugins.filter import backends
+
+
+class TestBackends:
+    def test_backends_in_groups_no_ssl(self):
+        hostvars = {
+            "1.2.3.4": {"inventory_hostname": "1.2.3.4"},
+            "1.2.3.5": {"inventory_hostname": "1.2.3.5"},
+            "1.2.3.6": {"inventory_hostname": "1.2.3.6"},
+            "1.2.3.7": {"inventory_hostname": "1.2.3.7"},
+        }
+        groups = {"backends": ["1.2.3.4", "1.2.3.5"]}
+
+        assert backends.backends(hostvars, groups) == [
+            "ws://1.2.3.4:8081",
+            "ws://1.2.3.5:8081",
+        ]
+
+    def test_backends_in_groups_ssl(self):
+        hostvars = {
+            "1.2.3.4": {"inventory_hostname": "1.2.3.4"},
+            "1.2.3.5": {"inventory_hostname": "1.2.3.5"},
+            "1.2.3.6": {
+                "inventory_hostname": "1.2.3.6",
+                "api_key_file": "path/to/key.file",
+            },
+            "1.2.3.7": {"inventory_hostname": "1.2.3.7"},
+        }
+        groups = {"backends": ["1.2.3.6"]}
+
+        assert backends.backends(hostvars, groups) == ["wss://1.2.3.6:8081"]
+
+    def test_backends_not_in_groups(self):
+        hostvars = {
+            "1.2.3.4": {"inventory_hostname": "1.2.3.4"},
+            "1.2.3.5": {"inventory_hostname": "1.2.3.5"},
+            "1.2.3.6": {"inventory_hostname": "1.2.3.6"},
+            "1.2.3.7": {"inventory_hostname": "1.2.3.7"},
+        }
+        groups = {}
+
+        assert backends.backends(hostvars, groups) == []


### PR DESCRIPTION
In the initial implementation of the automatic agent <-> backend linking, we assumed that the backends group will always be present in the inventory. Of course, we were completely wrong about that ;)

To address the limitation we just described, we moved the group selection into the filter. And while this might feel a bit wrong at the start, it is not all that bad. The filter is already named backends and highly specialized for a certain task. So nothing tragic happened here.

Note that we could still solve this problem in the default variable file using the attr and default filters, but we decided to go with the customized filter route. This keeps markup minimalistic and all the
logic in the python code where we can unit test it.

Fixes #114 