### PR TITLE
Synchronize collection metadata

### DIFF
--- a/plugins/modules/asset.py
+++ b/plugins/modules/asset.py
@@ -22,10 +22,11 @@ author:
   - Manca Bizjak (@mancabizjak)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu assets
+short_description: Manage Sensu assets
 description:
+  - Create, update or delete Sensu Go asset.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/assets/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/assets/).
 version_added: 0.1.0
 extends_documentation_fragment:
   - sensu.sensu_go.auth

--- a/plugins/modules/asset.py
+++ b/plugins/modules/asset.py
@@ -10,8 +10,8 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "XLAB Steampunk",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
 }
 
 DOCUMENTATION = """
@@ -27,7 +27,7 @@ description:
   - Create, update or delete Sensu Go asset.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/assets/).
-version_added: 0.1.0
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/asset_info.py
+++ b/plugins/modules/asset_info.py
@@ -21,10 +21,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu assets
+short_description: List Sensu assets
 description:
+  - Retrieve information about Sensu Go assets.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/assets/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/assets/).
 version_added: 0.0.1
 extends_documentation_fragment:
   - sensu.sensu_go.auth

--- a/plugins/modules/asset_info.py
+++ b/plugins/modules/asset_info.py
@@ -10,8 +10,8 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "community",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
 }
 
 DOCUMENTATION = """
@@ -26,7 +26,7 @@ description:
   - Retrieve information about Sensu Go assets.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/assets/).
-version_added: 0.0.1
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/bonsai_asset.py
+++ b/plugins/modules/bonsai_asset.py
@@ -9,8 +9,8 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "XLAB Steampunk",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
 }
 
 DOCUMENTATION = """
@@ -26,7 +26,7 @@ description:
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/assets/)
     and U(https://bonsai.sensu.io/)
-version_added: 0.1.0
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/bonsai_asset.py
+++ b/plugins/modules/bonsai_asset.py
@@ -21,6 +21,8 @@ author:
   - Tadej Borovsak (@tadeboro)
 short_description: Add Sensu assets from Bonsai
 description:
+  - Create or update a Sensu Go asset whose definition is available in the
+    Bonsai, the Sensu asset index.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/assets/)
     and U(https://bonsai.sensu.io/)

--- a/plugins/modules/check.py
+++ b/plugins/modules/check.py
@@ -9,9 +9,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: check
@@ -25,7 +27,7 @@ description:
   - Create, update or delete Sensu Go check.
   - For more information, refer to the Sensu Go documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/checks/).
-version_added: 0.1.0
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/check.py
+++ b/plugins/modules/check.py
@@ -20,10 +20,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu checks
+short_description: Manage Sensu checks
 description:
-  - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/checks/)
+  - Create, update or delete Sensu Go check.
+  - For more information, refer to the Sensu Go documentation at
+    U(https://docs.sensu.io/sensu-go/latest/reference/checks/).
 version_added: 0.1.0
 extends_documentation_fragment:
   - sensu.sensu_go.auth

--- a/plugins/modules/check_info.py
+++ b/plugins/modules/check_info.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: check_info
@@ -24,7 +26,7 @@ description:
   - Retrieve information about Sensu Go checks.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/checks/).
-version_added: 0.1.0
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/check_info.py
+++ b/plugins/modules/check_info.py
@@ -19,9 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu checks
+short_description: List Sensu checks
 description:
-  - 'For more information, refer to the Sensu documentation: U(https://docs.sensu.io/sensu-go/latest/reference/checks/)'
+  - Retrieve information about Sensu Go checks.
+  - For more information, refer to the Sensu documentation at
+    U(https://docs.sensu.io/sensu-go/latest/reference/checks/).
 version_added: 0.1.0
 extends_documentation_fragment:
   - sensu.sensu_go.auth

--- a/plugins/modules/cluster_role.py
+++ b/plugins/modules/cluster_role.py
@@ -19,10 +19,11 @@ author:
  - Manca Bizjak (@mancabizjak)
  - Aljaz Kosir (@aljazkosir)
  - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu cluster roles
+short_description: Manage Sensu cluster roles
 description:
+  - Create, update or delete Sensu role.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#roles-and-cluster-roles).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/cluster_role.py
+++ b/plugins/modules/cluster_role.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: cluster_role
@@ -24,6 +26,7 @@ description:
   - Create, update or delete Sensu role.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#roles-and-cluster-roles).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/cluster_role_binding.py
+++ b/plugins/modules/cluster_role_binding.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: cluster_role_binding
@@ -24,6 +26,7 @@ description:
   - Create, update or delete Sensu cluster role binding.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#role-bindings-and-cluster-role-bindings).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/cluster_role_binding.py
+++ b/plugins/modules/cluster_role_binding.py
@@ -19,10 +19,11 @@ author:
  - Manca Bizjak (@mancabizjak)
  - Aljaz Kosir (@aljazkosir)
  - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu cluster role bindings
+short_description: Manage Sensu cluster role bindings
 description:
+  - Create, update or delete Sensu cluster role binding.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#role-bindings-and-cluster-role-bindings).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/cluster_role_binding_info.py
+++ b/plugins/modules/cluster_role_binding_info.py
@@ -20,10 +20,11 @@ author:
   - Manca Bizjak (@mancabizjak)
   - Aljaz Kosir (@aljazkosir)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu cluster role bindings
+short_description: List Sensu cluster role bindings
 description:
+  - Retrieve information about Sensu cluster role bindings.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#role-bindings-and-cluster-role-bindings).
 notes:
   - Parameter C(auth.namespace) is ignored in this module.
 extends_documentation_fragment:

--- a/plugins/modules/cluster_role_binding_info.py
+++ b/plugins/modules/cluster_role_binding_info.py
@@ -9,9 +9,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: cluster_role_binding_info
@@ -25,6 +27,7 @@ description:
   - Retrieve information about Sensu cluster role bindings.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#role-bindings-and-cluster-role-bindings).
+version_added: "1.0"
 notes:
   - Parameter C(auth.namespace) is ignored in this module.
 extends_documentation_fragment:

--- a/plugins/modules/cluster_role_info.py
+++ b/plugins/modules/cluster_role_info.py
@@ -9,9 +9,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: cluster_role_info
@@ -25,6 +27,7 @@ description:
   - Retrieve information about Sensu roles.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#roles-and-cluster-roles).
+version_added: "1.0"
 notes:
   - Parameter C(auth.namespace) is ignored in this module.
 extends_documentation_fragment:

--- a/plugins/modules/cluster_role_info.py
+++ b/plugins/modules/cluster_role_info.py
@@ -20,10 +20,11 @@ author:
   - Manca Bizjak (@mancabizjak)
   - Aljaz Kosir (@aljazkosir)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu cluster roles
+short_description: List Sensu cluster roles
 description:
+  - Retrieve information about Sensu roles.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#roles-and-cluster-roles).
 notes:
   - Parameter C(auth.namespace) is ignored in this module.
 extends_documentation_fragment:

--- a/plugins/modules/entity.py
+++ b/plugins/modules/entity.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB community'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: entity
@@ -24,6 +26,7 @@ description:
   - Create, update or delete Sensu entity.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/entities/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/entity.py
+++ b/plugins/modules/entity.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu entities
+short_description: Manage Sensu entities
 description:
+  - Create, update or delete Sensu entity.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/entities/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/entities/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/entity_info.py
+++ b/plugins/modules/entity_info.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu entities
+short_description: List Sensu entities
 description:
+  - Retrieve information about Sensu entities.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/entities/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/entities/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/entity_info.py
+++ b/plugins/modules/entity_info.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: entity_info
@@ -24,6 +26,7 @@ description:
   - Retrieve information about Sensu entities.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/entities/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/event.py
+++ b/plugins/modules/event.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: event
@@ -24,6 +26,7 @@ description:
   - Send a synthetic event to Sensu.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/events/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
 notes:

--- a/plugins/modules/event.py
+++ b/plugins/modules/event.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Manca Bizjak (@mancabizjak)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu events
+short_description: Manage Sensu events
 description:
+  - Send a synthetic event to Sensu.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/events/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/events/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
 notes:

--- a/plugins/modules/event_info.py
+++ b/plugins/modules/event_info.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Manca Bizjak (@mancabizjak)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu events
+short_description: List Sensu events
 description:
+  - Retrieve recent events that Sensu processed.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/events/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/events/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
 options:

--- a/plugins/modules/event_info.py
+++ b/plugins/modules/event_info.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: event_info
@@ -24,6 +26,7 @@ description:
   - Retrieve recent events that Sensu processed.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/events/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
 options:

--- a/plugins/modules/filter.py
+++ b/plugins/modules/filter.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu filters
+short_description: Manage Sensu filters
 description:
+  - Create, update or delete Sensu filter.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/filters/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/filters/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/filter.py
+++ b/plugins/modules/filter.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: filter
@@ -24,6 +26,7 @@ description:
   - Create, update or delete Sensu filter.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/filters/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/filter_info.py
+++ b/plugins/modules/filter_info.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu info
+short_description: List Sensu info
 description:
+  - Retrieve information about Sensu filters.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/filters/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/filters/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/filter_info.py
+++ b/plugins/modules/filter_info.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: filter_info
@@ -24,6 +26,7 @@ description:
   - Retrieve information about Sensu filters.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/filters/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/handler_info.py
+++ b/plugins/modules/handler_info.py
@@ -17,10 +17,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu hanlders
+short_description: List Sensu handlers
 description:
+  - Retrieve information about Sensu handlers.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/handlers/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/handlers/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/handler_info.py
+++ b/plugins/modules/handler_info.py
@@ -7,9 +7,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: handler_info
@@ -22,6 +24,7 @@ description:
   - Retrieve information about Sensu handlers.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/handlers/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/handler_set.py
+++ b/plugins/modules/handler_set.py
@@ -17,10 +17,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu handler set
+short_description: Manage Sensu handler set
 description:
+  - Create, update or delete Sensu handler set.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/handlers/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/handlers/#handler-sets).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/handler_set.py
+++ b/plugins/modules/handler_set.py
@@ -7,9 +7,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: handler_set
@@ -22,6 +24,7 @@ description:
   - Create, update or delete Sensu handler set.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/handlers/#handler-sets).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/hook.py
+++ b/plugins/modules/hook.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu hooks
+short_description: Manage Sensu hooks
 description:
+  - Create, update or delete Sensu hook.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/hooks/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/hooks/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/hook.py
+++ b/plugins/modules/hook.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: hook
@@ -24,6 +26,7 @@ description:
   - Create, update or delete Sensu hook.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/hooks/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/hook_info.py
+++ b/plugins/modules/hook_info.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: hook_info
@@ -24,6 +26,7 @@ description:
   - Retrieve information about Sensu hooks.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/hooks/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/hook_info.py
+++ b/plugins/modules/hook_info.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu hooks
+short_description: List Sensu hooks
 description:
+  - Retrieve information about Sensu hooks.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/hooks/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/hooks/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/mutator.py
+++ b/plugins/modules/mutator.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu mutators
+short_description: Manage Sensu mutators
 description:
+  - Create, update or delete Sensu mutator.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/mutators/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/mutators/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/mutator.py
+++ b/plugins/modules/mutator.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: mutator
@@ -24,6 +26,7 @@ description:
   - Create, update or delete Sensu mutator.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/mutators/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/mutator_info.py
+++ b/plugins/modules/mutator_info.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: mutator_info
@@ -24,7 +26,7 @@ description:
   - Retrieve information about Sensu mutators.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/mutators/).
-version_added: 0.1.0
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/mutator_info.py
+++ b/plugins/modules/mutator_info.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu mutators
+short_description: List Sensu mutators
 description:
+  - Retrieve information about Sensu mutators.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/mutators/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/mutators/).
 version_added: 0.1.0
 extends_documentation_fragment:
   - sensu.sensu_go.auth

--- a/plugins/modules/namespace.py
+++ b/plugins/modules/namespace.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: namespace
@@ -24,6 +26,7 @@ description:
   - Create, update or delete Sensu namespace.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#namespaces).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/namespace.py
+++ b/plugins/modules/namespace.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu namespaces
+short_description: Manage Sensu namespaces
 description:
+  - Create, update or delete Sensu namespace.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#namespaces)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#namespaces).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/namespace_info.py
+++ b/plugins/modules/namespace_info.py
@@ -7,9 +7,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: namespace_info
@@ -23,6 +25,7 @@ description:
   - Retrieve information about Sensu namespaces.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#namespaces).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
 notes:

--- a/plugins/modules/namespace_info.py
+++ b/plugins/modules/namespace_info.py
@@ -18,10 +18,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu namespaces
+short_description: List Sensu namespaces
 description:
+  - Retrieve information about Sensu namespaces.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#namespaces)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#namespaces).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
 notes:

--- a/plugins/modules/pipe_handler.py
+++ b/plugins/modules/pipe_handler.py
@@ -17,10 +17,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu pipe handler
+short_description: Manage Sensu pipe handler
 description:
+  - Create, update or delete Sensu pip handler.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/handlers/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/handlers/#pipe-handlers).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/pipe_handler.py
+++ b/plugins/modules/pipe_handler.py
@@ -7,9 +7,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: pipe_handler
@@ -22,6 +24,7 @@ description:
   - Create, update or delete Sensu pip handler.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/handlers/#pipe-handlers).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -19,10 +19,11 @@ author:
  - Manca Bizjak (@mancabizjak)
  - Aljaz Kosir (@aljazkosir)
  - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu roles
+short_description: Manage Sensu roles
 description:
+  - Create, update or delete Sensu role.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#roles-and-cluster-roles).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: role
@@ -24,6 +26,7 @@ description:
   - Create, update or delete Sensu role.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#roles-and-cluster-roles).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/role_binding.py
+++ b/plugins/modules/role_binding.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: role_binding
@@ -24,6 +26,7 @@ description:
   - Create, update or delete Sensu role binding.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#role-bindings-and-cluster-role-bindings).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/role_binding.py
+++ b/plugins/modules/role_binding.py
@@ -19,10 +19,11 @@ author:
  - Manca Bizjak (@mancabizjak)
  - Aljaz Kosir (@aljazkosir)
  - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu role bindings
+short_description: Manage Sensu role bindings
 description:
+  - Create, update or delete Sensu role binding.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#role-bindings-and-cluster-role-bindings).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/role_binding_info.py
+++ b/plugins/modules/role_binding_info.py
@@ -9,9 +9,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: role_binding_info
@@ -25,7 +27,7 @@ description:
   - Retrieve information about Sensu role bindings.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#role-bindings-and-cluster-role-bindings).
-version_added: 0.1.0
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/role_binding_info.py
+++ b/plugins/modules/role_binding_info.py
@@ -20,10 +20,11 @@ author:
   - Manca Bizjak (@mancabizjak)
   - Aljaz Kosir (@aljazkosir)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu role bindings
+short_description: List Sensu role bindings
 description:
+  - Retrieve information about Sensu role bindings.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#role-bindings-and-cluster-role-bindings).
 version_added: 0.1.0
 extends_documentation_fragment:
   - sensu.sensu_go.auth

--- a/plugins/modules/role_info.py
+++ b/plugins/modules/role_info.py
@@ -9,9 +9,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: role_info
@@ -25,7 +27,7 @@ description:
   - Retrieve information about Sensu roles.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#roles-and-cluster-roles).
-version_added: 0.1.0
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.info

--- a/plugins/modules/role_info.py
+++ b/plugins/modules/role_info.py
@@ -20,10 +20,11 @@ author:
   - Manca Bizjak (@mancabizjak)
   - Aljaz Kosir (@aljazkosir)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu roles
+short_description: List Sensu roles
 description:
+  - Retrieve information about Sensu roles.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#roles-and-cluster-roles).
 version_added: 0.1.0
 extends_documentation_fragment:
   - sensu.sensu_go.auth

--- a/plugins/modules/silence.py
+++ b/plugins/modules/silence.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Manca Bizjak (@mancabizjak)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu silences
+short_description: Manage Sensu silences
 description:
+  - Create, update or delete Sensu silence.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/silencing/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/silencing/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.state

--- a/plugins/modules/silence.py
+++ b/plugins/modules/silence.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: silence
@@ -24,6 +26,7 @@ description:
   - Create, update or delete Sensu silence.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/silencing/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.state

--- a/plugins/modules/silence_info.py
+++ b/plugins/modules/silence_info.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: silence_info
@@ -24,6 +26,7 @@ description:
   - Retrieve information about Sensu silences.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/silencing/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
 options:

--- a/plugins/modules/silence_info.py
+++ b/plugins/modules/silence_info.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Manca Bizjak (@mancabizjak)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu silence entries
+short_description: List Sensu silence entries
 description:
+  - Retrieve information about Sensu silences.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/silences/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/silencing/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
 options:

--- a/plugins/modules/socket_handler.py
+++ b/plugins/modules/socket_handler.py
@@ -17,10 +17,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu TCP/UDP handler
+short_description: Manage Sensu TCP/UDP handler
 description:
+  - Create, update or delete Sensu socket handler.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/handlers/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/handlers/#tcp-udp-handlers).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/socket_handler.py
+++ b/plugins/modules/socket_handler.py
@@ -7,9 +7,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: socket_handler
@@ -22,6 +24,7 @@ description:
   - Create, update or delete Sensu socket handler.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/handlers/#tcp-udp-handlers).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/tessen.py
+++ b/plugins/modules/tessen.py
@@ -19,15 +19,15 @@ author:
  - Manca Bizjak (@mancabizjak)
  - Aljaz Kosir (@aljazkosir)
  - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu's tessen configuration.
+short_description: Manage Sensu's Tessen configuration.
 description:
-  - Sensu Tessen is enabled by default on Sensu backends
+  - Enable or disable Tessen service.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/tessen/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/tessen/).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
 notes:
-  - Parameter C(auth.namespace) is ignored in this module, because tessen is configured globally.
+  - Parameter C(auth.namespace) is ignored in this module, because Tessen is configured globally.
 options:
   state:
     description:

--- a/plugins/modules/tessen.py
+++ b/plugins/modules/tessen.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: tessen
@@ -24,6 +26,7 @@ description:
   - Enable or disable Tessen service.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/tessen/).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
 notes:

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -18,10 +18,11 @@ author:
   - Paul Arthur (@flowerysong)
   - Aljaz Kosir (@aljazkosir)
   - Tadej Borovsak (@tadeboro)
-short_description: Manages Sensu users
+short_description: Manage Sensu users
 description:
+  - Create, update, activate or deactivate Sensu user.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/users/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#users).
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: user
@@ -23,6 +25,7 @@ description:
   - Create, update, activate or deactivate Sensu user.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#users).
+version_added: "1.0"
 extends_documentation_fragment:
   - sensu.sensu_go.auth
   - sensu.sensu_go.name

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -8,9 +8,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'XLAB Steampunk'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = '''
 module: user_info
@@ -24,6 +26,7 @@ description:
   - Retrieve information about Sensu users.
   - For more information, refer to the Sensu documentation at
     U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#users).
+version_added: "1.0"
 notes:
   - Parameter C(auth.namespace) is ignored in this module.
 extends_documentation_fragment:

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -19,10 +19,11 @@ author:
   - Aljaz Kosir (@aljazkosir)
   - Miha Plesko (@miha-plesko)
   - Tadej Borovsak (@tadeboro)
-short_description: Lists Sensu users
+short_description: List Sensu users
 description:
+  - Retrieve information about Sensu users.
   - For more information, refer to the Sensu documentation at
-    U(https://docs.sensu.io/sensu-go/latest/reference/users/)
+    U(https://docs.sensu.io/sensu-go/latest/reference/rbac/#users).
 notes:
   - Parameter C(auth.namespace) is ignored in this module.
 extends_documentation_fragment:


### PR DESCRIPTION
Changes in this PR do two main things:

 1. Unify the module documentation snippets.
 2. Unify the module metadata.

See commit messages for more details.

Fixes #38 