### PR TITLE
Make info modules return empty list if item is missing

### DIFF
--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -89,3 +89,9 @@ def dict_to_key_value_strings(data):
 
 def build_url_path(*parts):
     return "/" + "/".join(quote(p, safe="") for p in parts if p)
+
+
+def prepare_result_list(result):
+    if isinstance(result, list):
+        return result
+    return [] if result is None else [result]

--- a/plugins/modules/asset_info.py
+++ b/plugins/modules/asset_info.py
@@ -65,12 +65,10 @@ def main():
     path = utils.build_url_path("assets", module.params["name"])
 
     try:
-        assets = utils.get(client, path)
+        assets = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        assets = [assets]
     module.exit_json(changed=False, objects=assets)
 
 

--- a/plugins/modules/check_info.py
+++ b/plugins/modules/check_info.py
@@ -64,12 +64,10 @@ def main():
     path = utils.build_url_path("checks", module.params["name"])
 
     try:
-        checks = utils.get(client, path)
+        checks = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        checks = [checks]
     module.exit_json(changed=False, objects=checks)
 
 

--- a/plugins/modules/cluster_role_binding_info.py
+++ b/plugins/modules/cluster_role_binding_info.py
@@ -68,12 +68,12 @@ def main():
     path = utils.build_url_path("clusterrolebindings", module.params["name"])
 
     try:
-        cluster_role_bindings = utils.get(client, path)
+        cluster_role_bindings = utils.prepare_result_list(
+            utils.get(client, path)
+        )
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        cluster_role_bindings = [cluster_role_bindings]
     module.exit_json(changed=False, objects=cluster_role_bindings)
 
 

--- a/plugins/modules/cluster_role_info.py
+++ b/plugins/modules/cluster_role_info.py
@@ -68,12 +68,10 @@ def main():
     path = utils.build_url_path("clusterroles", module.params["name"])
 
     try:
-        cluster_roles = utils.get(client, path)
+        cluster_roles = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        cluster_roles = [cluster_roles]
     module.exit_json(changed=False, objects=cluster_roles)
 
 

--- a/plugins/modules/entity_info.py
+++ b/plugins/modules/entity_info.py
@@ -64,12 +64,10 @@ def main():
     path = utils.build_url_path("entities", module.params["name"])
 
     try:
-        entities = utils.get(client, path)
+        entities = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        entities = [entities]
     module.exit_json(changed=False, objects=entities)
 
 

--- a/plugins/modules/event_info.py
+++ b/plugins/modules/event_info.py
@@ -89,12 +89,10 @@ def main():
     )
 
     try:
-        events = utils.get(client, path)
+        events = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params['check']:
-        events = [events]
     module.exit_json(changed=False, objects=events)
 
 

--- a/plugins/modules/filter_info.py
+++ b/plugins/modules/filter_info.py
@@ -64,12 +64,10 @@ def main():
     path = utils.build_url_path("filters", module.params["name"])
 
     try:
-        sensu_filters = utils.get(client, path)
+        sensu_filters = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        sensu_filters = [sensu_filters]
     module.exit_json(changed=False, objects=sensu_filters)
 
 

--- a/plugins/modules/handler_info.py
+++ b/plugins/modules/handler_info.py
@@ -62,12 +62,10 @@ def main():
     path = utils.build_url_path("handlers", module.params["name"])
 
     try:
-        handlers = utils.get(client, path)
+        handlers = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        handlers = [handlers]
     module.exit_json(changed=False, objects=handlers)
 
 

--- a/plugins/modules/hook_info.py
+++ b/plugins/modules/hook_info.py
@@ -69,12 +69,10 @@ def main():
     path = utils.build_url_path("hooks", module.params["name"])
 
     try:
-        hooks = utils.get(client, path)
+        hooks = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        hooks = [hooks]
     module.exit_json(changed=False, objects=hooks)
 
 

--- a/plugins/modules/mutator_info.py
+++ b/plugins/modules/mutator_info.py
@@ -64,12 +64,10 @@ def main():
     path = utils.build_url_path("mutators", module.params["name"])
 
     try:
-        mutators = utils.get(client, path)
+        mutators = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        mutators = [mutators]
     module.exit_json(changed=False, objects=mutators)
 
 

--- a/plugins/modules/role_binding_info.py
+++ b/plugins/modules/role_binding_info.py
@@ -65,12 +65,10 @@ def main():
     path = utils.build_url_path("rolebindings", module.params["name"])
 
     try:
-        role_bindings = utils.get(client, path)
+        role_bindings = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        role_bindings = [role_bindings]
     module.exit_json(changed=False, objects=role_bindings)
 
 

--- a/plugins/modules/role_info.py
+++ b/plugins/modules/role_info.py
@@ -65,12 +65,10 @@ def main():
     path = utils.build_url_path("roles", module.params["name"])
 
     try:
-        roles = utils.get(client, path)
+        roles = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        roles = [roles]
     module.exit_json(changed=False, objects=roles)
 
 

--- a/plugins/modules/silence_info.py
+++ b/plugins/modules/silence_info.py
@@ -82,12 +82,10 @@ def main():
     path = utils.build_url_path("silenced", None if name == "*:*" else name)
 
     try:
-        silences = utils.get(client, path)
+        silences = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if name != '*:*':
-        silences = [silences]
     module.exit_json(changed=False, objects=silences)
 
 

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -66,12 +66,10 @@ def main():
     path = utils.build_url_path("users", module.params["name"])
 
     try:
-        users = utils.get(client, path)
+        users = utils.prepare_result_list(utils.get(client, path))
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if module.params["name"]:
-        users = [users]
     module.exit_json(changed=False, objects=users)
 
 

--- a/tests/integration/molecule/module_asset/playbook.yml
+++ b/tests/integration/molecule/module_asset/playbook.yml
@@ -198,3 +198,14 @@
         that:
           - result.objects | length == 2
           - result.objects.0.metadata.name == 'asset'
+
+    - name: Try to fetch non-existing asset
+      asset_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-asset
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_check/playbook.yml
+++ b/tests/integration/molecule/module_check/playbook.yml
@@ -186,3 +186,14 @@
         that:
           - result.objects | length == 2
           - result.objects.0.metadata.name == 'check2'
+
+    - name: Try to fetch non-existing check
+      check_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-check
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_cluster_role/playbook.yml
+++ b/tests/integration/molecule/module_cluster_role/playbook.yml
@@ -206,3 +206,14 @@
     - assert:
         that:
           - result.objects | length == 7 # There are 6 default cluster roles
+
+    - name: Try to fetch non-existing role
+      cluster_role_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-role
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_cluster_role_binding/playbook.yml
+++ b/tests/integration/molecule/module_cluster_role_binding/playbook.yml
@@ -181,3 +181,14 @@
     - assert:
         that:
           - result.objects | length == 5 # There are 3 pre-existing cluster role bindings by default
+
+    - name: Try to fetch non-existing binding
+      cluster_role_binding_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-binding
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_entity/playbook.yml
+++ b/tests/integration/molecule/module_entity/playbook.yml
@@ -171,3 +171,14 @@
         that:
           - result.objects | length == 2
           - result.objects.0.metadata.name == 'entity2'
+
+    - name: Try to fetch non-existing entity
+      entity_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-entity
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_event/playbook.yml
+++ b/tests/integration/molecule/module_event/playbook.yml
@@ -66,6 +66,18 @@
           - also_checks
         interval: 30
 
+    - name: Get non-existing last event for entity and check combo
+      event_info:
+        auth:
+          url: http://localhost:8080
+        entity: awesome_entity
+        check: awesome_check
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []
+
     - name: Create event with minimal parameters
       event:
         auth:

--- a/tests/integration/molecule/module_filter/playbook.yml
+++ b/tests/integration/molecule/module_filter/playbook.yml
@@ -137,3 +137,14 @@
         that:
           - result.objects | length == 2
           - result.objects.0.metadata.name == 'filter2'
+
+    - name: Try to fetch non-existing filter
+      filter_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-filter
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_handler_set/playbook.yml
+++ b/tests/integration/molecule/module_handler_set/playbook.yml
@@ -86,3 +86,14 @@
     - assert:
         that:
           - result.objects | length == 0
+
+    - name: Try to fetch non-existing handler
+      handler_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-handler
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_hook/playbook.yml
+++ b/tests/integration/molecule/module_hook/playbook.yml
@@ -126,3 +126,14 @@
         that:
           - result.objects | length == 2
           - result.objects.0.metadata.name == 'hook2'
+
+    - name: Try to fetch non-existing hook
+      hook_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-hook
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_mutator/playbook.yml
+++ b/tests/integration/molecule/module_mutator/playbook.yml
@@ -127,3 +127,14 @@
         that:
           - result.objects | length == 2
           - result.objects.0.metadata.name == 'minimal_mutator'
+
+    - name: Try to fetch non-existing mutator
+      mutator_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-mutator
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_role/playbook.yml
+++ b/tests/integration/molecule/module_role/playbook.yml
@@ -206,3 +206,14 @@
     - assert:
         that:
           - result.objects | length == 1
+
+    - name: Try to fetch non-existing role
+      role_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-role
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_role_binding/playbook.yml
+++ b/tests/integration/molecule/module_role_binding/playbook.yml
@@ -217,3 +217,14 @@
     - assert:
         that:
           - result.objects | length == 3
+
+    - name: Try to fetch non-existing binding
+      role_binding_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-binding
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_silence/playbook.yml
+++ b/tests/integration/molecule/module_silence/playbook.yml
@@ -173,3 +173,15 @@
           - result.objects | length == 3
           - result.objects.0.subscription == 'agent'
           - "'check' not in result.objects.0"
+
+    - name: Try to fetch non-existing silence
+      silence_info:
+        auth:
+          url: http://localhost:8080
+        subscription: bad
+        check: bad
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/integration/molecule/module_user/playbook.yml
+++ b/tests/integration/molecule/module_user/playbook.yml
@@ -123,3 +123,14 @@
     - assert:
         that:
           - result is failed
+
+    - name: Try to fetch non-existing user
+      user_info:
+        auth:
+          url: http://localhost:8080
+        name: bad-bad-user
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []

--- a/tests/unit/module_utils/test_utils.py
+++ b/tests/unit/module_utils/test_utils.py
@@ -262,3 +262,15 @@ class TestBuildUrlPath:
     ])
     def test_build_url_path(self, parts, expectation):
         assert expectation == utils.build_url_path(*parts)
+
+
+class TestPrepareResultList:
+    @pytest.mark.parametrize("input,output", [
+        (None, []),  # this is mosti likely result of a 404 status
+        ("a", ["a"]),
+        ([], []),
+        ([1, 2, 3], [1, 2, 3]),
+        ([None], [None]),  # we leave lists intact, even if they contain None
+    ])
+    def test_list_construction(self, input, output):
+        assert output == utils.prepare_result_list(input)

--- a/tests/unit/modules/test_asset_info.py
+++ b/tests/unit/modules/test_asset_info.py
@@ -38,6 +38,16 @@ class TestAssetInfo(ModuleTestCase):
         assert path == "/assets/sample-asset"
         assert context.value.args[0]["objects"] == [4]
 
+    def test_missing_single_asset(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-asset")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            asset_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_check_info.py
+++ b/tests/unit/modules/test_check_info.py
@@ -38,6 +38,16 @@ class TestSensuGoCheckInfo(ModuleTestCase):
         assert path == "/checks/sample-check"
         assert context.value.args[0]["objects"] == [4]
 
+    def test_missing_single_check(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-check")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            check_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_cluster_role_binding_info.py
+++ b/tests/unit/modules/test_cluster_role_binding_info.py
@@ -38,6 +38,16 @@ class TestClusterRoleBindingInfo(ModuleTestCase):
         assert path == "/clusterrolebindings/test-cluster-role-binding"
         assert context.value.args[0]["objects"] == [1]
 
+    def test_missing_single_cluster_role_binding(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-cluster-role-binding")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            cluster_role_binding_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_cluster_role_info.py
+++ b/tests/unit/modules/test_cluster_role_info.py
@@ -38,6 +38,16 @@ class TestClusterRoleInfo(ModuleTestCase):
         assert path == "/clusterroles/test-cluster-role"
         assert context.value.args[0]["objects"] == [1]
 
+    def test_missing_single_cluster_role(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-cluster-role")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            cluster_role_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_entity_info.py
+++ b/tests/unit/modules/test_entity_info.py
@@ -38,6 +38,16 @@ class TestEntityInfo(ModuleTestCase):
         assert path == "/entities/sample-entity"
         assert context.value.args[0]["objects"] == [4]
 
+    def test_missing_single_entity(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-entity")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            entity_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_event_info.py
+++ b/tests/unit/modules/test_event_info.py
@@ -66,6 +66,19 @@ class TestEventInfo(ModuleTestCase):
         assert path == '/events/simple-entity/simple-check'
         assert context.value.args[0]['objects'] == [4]
 
+    def test_no_event_by_entity_and_check(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(
+            entity='simple-entity',
+            check='simple-check'
+        )
+
+        with pytest.raises(AnsibleExitJson) as context:
+            event_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, 'get')
         get_mock.side_effect = errors.Error('Bad error')

--- a/tests/unit/modules/test_filter_info.py
+++ b/tests/unit/modules/test_filter_info.py
@@ -38,6 +38,16 @@ class TestFilterInfo(ModuleTestCase):
         assert path == "/filters/sample-filter"
         assert context.value.args[0]["objects"] == [4]
 
+    def test_missing_single_filter(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-filter")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            filter_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_hook_info.py
+++ b/tests/unit/modules/test_hook_info.py
@@ -38,6 +38,16 @@ class TestHookInfo(ModuleTestCase):
         assert path == "/hooks/sample-hook"
         assert context.value.args[0]["objects"] == [4]
 
+    def test_missing_single_hook(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-hook")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            hook_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_mutator_info.py
+++ b/tests/unit/modules/test_mutator_info.py
@@ -38,6 +38,16 @@ class TestMutatorInfo(ModuleTestCase):
         assert path == "/mutators/sample-mutator"
         assert context.value.args[0]["objects"] == [4]
 
+    def test_missing_single_mutator(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-mutator")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            mutator_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_pipe_handler_info.py
+++ b/tests/unit/modules/test_pipe_handler_info.py
@@ -38,6 +38,16 @@ class TestHandlerInfo(ModuleTestCase):
         assert path == "/handlers/sample-handler"
         assert context.value.args[0]["objects"] == [4]
 
+    def test_missing_single_handler(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-handler")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            handler_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_role_binding_info.py
+++ b/tests/unit/modules/test_role_binding_info.py
@@ -38,6 +38,16 @@ class TestRoleBindingInfo(ModuleTestCase):
         assert path == "/rolebindings/test-role-binding"
         assert context.value.args[0]["objects"] == [1]
 
+    def test_missing_single_role_binding(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-role-binding")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            role_binding_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_role_info.py
+++ b/tests/unit/modules/test_role_info.py
@@ -38,6 +38,16 @@ class TestRoleInfo(ModuleTestCase):
         assert path == "/roles/test-role"
         assert context.value.args[0]["objects"] == [1]
 
+    def test_missing_single_role(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-role")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            role_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_silence_info.py
+++ b/tests/unit/modules/test_silence_info.py
@@ -38,6 +38,19 @@ class TestSilenceInfo(ModuleTestCase):
         assert path == "/silenced/subscription%3A%2A"  # %3A = :, %2A = *
         assert context.value.args[0]["objects"] == [4]
 
+    def test_missing_single_silence(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(
+            subscription="missing",
+            check="missing",
+        )
+
+        with pytest.raises(AnsibleExitJson) as context:
+            silence_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")

--- a/tests/unit/modules/test_user_info.py
+++ b/tests/unit/modules/test_user_info.py
@@ -38,6 +38,16 @@ class TestUserInfo(ModuleTestCase):
         assert path == "/users/sample-user"
         assert context.value.args[0]["objects"] == [4]
 
+    def test_missing_single_user(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-user")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            user_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
     def test_failure(self, mocker):
         get_mock = mocker.patch.object(utils, "get")
         get_mock.side_effect = errors.Error("Bad error")


### PR DESCRIPTION
When we initially wrote code info code, we did not give this aspect of the API much thought. This is why we ended in a situation where

    - asset_info:

and

    - asset_info:
        name: name

return different result when executed against an empty Sensu Go backend. The first task returns an empty list while the second task will return a list with a single None in it.

To unify the API, we made the second task also return an empty list. This also simplifies playbook tests for resource existence since the playbook authors can check the length of the list and see if there is anything in it without having to compare list content to None.

We implemented this using a pure filtering function that we inserted into all info modules. The only exception here is the namespace_info module that cannot query for a single namespace.

When we added a filtering function, we also made it smart enough to ignore double-wrapping the lists. Main reason for doing this is to get rid of the if check in every info module.

Note that we added integration and unit tests. The main purpose of our unit tests is to make sure our modules have the filter in place while the integration tests basically check compatibility with the Sensu Go backend.