### PR TITLE
Add external datastore modules

### DIFF
--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -71,7 +71,7 @@ def delete(client, path):
 
 def put(client, path, payload):
     resp = client.put(path, payload)
-    if resp.status != 201:
+    if resp.status not in (200, 201):
         _abort(
             "PUT {0} failed with status {1}: {2}",
             path, resp.status, resp.data,

--- a/plugins/modules/datastore.py
+++ b/plugins/modules/datastore.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = '''
+module: datastore
+author:
+  - Manca Bizjak (@mancabizjak)
+  - Tadej Borovsak (@tadeboro)
+short_description: Manage Sensu external datastore providers
+description:
+  - Add or remove external datastore provider.
+  - For more information, refer to the Sensu documentation at
+    U(https://docs.sensu.io/sensu-go/latest/reference/datastore/).
+version_added: "1.1"
+extends_documentation_fragment:
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.name
+  - sensu.sensu_go.state
+seealso:
+  - module: datastore_info
+options:
+  dsn:
+    description:
+      - Attribute that specifies the data source names as a URL or
+        PostgreSQL connection string. See the PostgreSQL docs for more
+        information about connection strings.
+    type: str
+  pool_size:
+    description:
+      - The maximum number of connections to hold in the PostgreSQL connection
+        pool.
+    type: int
+notes:
+  - Currently, only one external datastore can be active at a time. The module
+    will fail to perform its operation if this would break that invariant.
+'''
+
+EXAMPLES = '''
+- name: Add external datastore
+  datastore:
+    name: my-postgres
+    dsn: postgresql://user:secret@host:port/dbname
+
+- name: Remove external datastore
+  datastore:
+    name: my-postgres
+    state: absent
+'''
+
+RETURN = '''
+object:
+    description: object representing external datastore provider
+    returned: success
+    type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    arguments, errors, utils,
+)
+
+API_GROUP = "enterprise"
+API_VERSION = "store/v1"
+
+
+def _do_differ(remote, payload):
+    return utils.do_differ(remote["spec"], payload["spec"])
+
+
+def sync(state, client, list_path, resource_path, payload, check_mode):
+    datastore = utils.get(client, resource_path)
+
+    # When we are deleting stores, we do not care if there is more than one
+    # datastore present. We just make sure the currently manipulated store is
+    # gone. This makes our module useful in "let us clean up the mess"
+    # scenarios.
+    if state == "absent" and datastore is None:
+        return False, None
+
+    if state == "absent":
+        if not check_mode:
+            utils.delete(client, resource_path)
+        return True, None
+
+    # If the store exists, update it and ignore the fact that there might be
+    # more than one present.
+    if datastore:
+        if _do_differ(datastore, payload):
+            if check_mode:
+                return True, payload
+            utils.put(client, resource_path, payload)
+            return True, utils.get(client, resource_path)
+        return False, datastore
+
+    # When adding a new datastore, we first make sure there is no other
+    # datastore present because we do not want to be the ones who brought
+    # backends into an inconsistent state.
+    if utils.get(client, list_path):
+        raise errors.Error("Some other external datastore is already active.")
+
+    if check_mode:
+        return True, payload
+    utils.put(client, resource_path, payload)
+    return True, utils.get(client, resource_path)
+
+
+def main():
+    required_if = [
+        ("state", "present", ["dsn"])
+    ]
+    module = AnsibleModule(
+        required_if=required_if,
+        supports_check_mode=True,
+        argument_spec=dict(
+            arguments.get_spec("auth", "name", "state"),
+            dsn=dict(),
+            pool_size=dict(
+                type="int",
+            )
+        ),
+    )
+
+    client = arguments.get_sensu_client(module.params["auth"])
+    list_path = utils.build_url_path(API_GROUP, API_VERSION, None, "provider")
+    resource_path = utils.build_url_path(
+        API_GROUP, API_VERSION, None, "provider", module.params["name"],
+    )
+    payload = dict(
+        type="PostgresConfig",
+        api_version=API_VERSION,
+        spec=arguments.get_mutation_payload(module.params, "dsn", "pool_size"),
+    )
+
+    try:
+        changed, datastore = sync(
+            module.params["state"], client, list_path, resource_path, payload,
+            module.check_mode,
+        )
+        # We simulate the behavior of v2 API here and only return the spec.
+        module.exit_json(
+            changed=changed, object=datastore and datastore["spec"],
+        )
+    except errors.Error as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/datastore_info.py
+++ b/plugins/modules/datastore_info.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+module: datastore_info
+author:
+  - Manca Bizjak (@mancabizjak)
+  - Tadej Borovsak (@tadeboro)
+short_description: List external Sensu datastore providers
+description:
+  - Retrieve information about external Sensu datastores.
+  - For more information, refer to the Sensu documentation at
+    U(https://docs.sensu.io/sensu-go/latest/reference/datastore/).
+version_added: "1.1"
+extends_documentation_fragment:
+  - sensu.sensu_go.auth
+  - sensu.sensu_go.info
+seealso:
+  - module: datastore
+"""
+
+EXAMPLES = """
+- name: List all external Sensu datastores
+  datastore_info:
+  register: result
+
+- name: Retrieve the selected external Sensu datastore
+  datastore_info:
+    name: my-datastore
+  register: result
+
+- name: Do something with result
+  debug:
+    msg: "{{ result.objects.0.dsn }}"
+"""
+
+RETURN = """
+objects:
+  description: list of external Sensu datastore providers
+  returned: always
+  type: list
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    arguments, errors, utils,
+)
+
+API_GROUP = "enterprise"
+API_VERSION = "store/v1"
+
+
+def main():
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            arguments.get_spec("auth"),
+            name=dict(),  # Name is not required in info modules.
+        ),
+    )
+
+    client = arguments.get_sensu_client(module.params["auth"])
+    path = utils.build_url_path(
+        API_GROUP, API_VERSION, None, "provider", module.params["name"],
+    )
+
+    try:
+        stores = utils.prepare_result_list(utils.get(client, path))
+        # We simulate the behavior of v2 API here and only return the spec.
+        module.exit_json(changed=False, objects=[s["spec"] for s in stores])
+    except errors.Error as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/tessen.py
+++ b/plugins/modules/tessen.py
@@ -66,21 +66,13 @@ def get(client, path):
     return resp.json
 
 
-def put(client, path, payload):
-    resp = client.put(path, payload)
-    if resp.status != 200:
-        raise errors.SyncError(
-            "PUT {0} failed with status {1}: {2}".format(path, resp.status, resp.data))
-    return None
-
-
 def sync(client, path, payload, check_mode):
     remote_object = get(client, path)
 
     if utils.do_differ(remote_object, payload):
         if check_mode:
             return True, payload
-        put(client, path, payload)
+        utils.put(client, path, payload)
         return True, get(client, path)
 
     return False, remote_object

--- a/tests/integration/molecule/module_datastore/molecule.yml
+++ b/tests/integration/molecule/module_datastore/molecule.yml
@@ -1,0 +1,6 @@
+platforms:
+  - name: v5.15.0
+    image: xlabsi/sensu:5.15.0
+    pre_build_image: true
+    pull: true
+    override_command: false

--- a/tests/integration/molecule/module_datastore/playbook.yml
+++ b/tests/integration/molecule/module_datastore/playbook.yml
@@ -1,0 +1,133 @@
+---
+- name: Converge
+  collections:
+    - sensu.sensu_go
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Retrieve empty list of external datastores
+      datastore_info:
+        auth: &auth
+          url: http://localhost:8080
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []
+
+    - name: Make sure we fail creation if dsn parameter is missing
+      datastore:
+        auth: *auth
+        name: my-incomplete-datastore
+      register: result
+      ignore_errors: true
+
+    - assert:
+        that:
+          - result is failed
+
+    - name: Enable external datastore with minimal parameters
+      datastore: &idempotence
+        auth: *auth
+        name: my-datastore
+        dsn: postgresql://user:secret@host:port/dbname
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.metadata.name == "my-datastore"
+          - result.object.dsn == "postgresql://user:secret@host:port/dbname"
+
+    - name: Check for idempotence
+      datastore: *idempotence
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Try to add another external storage
+      datastore:
+        auth: *auth
+        name: my-second-datastore
+        dsn: postgresql://user:secret@host:port/db
+        pool_size: 123
+      register: result
+      ignore_errors: true
+
+    - assert:
+        that:
+          - result is failed
+
+    - name: Update external datastore
+      datastore:
+        auth: *auth
+        name: my-datastore
+        dsn: postgresql://user:secret@host:port/new
+        pool_size: 321
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.metadata.name == "my-datastore"
+          - result.object.dsn == "postgresql://user:secret@host:port/new"
+          - result.object.pool_size == 321
+
+    - name: Fetch all datastores
+      datastore_info:
+        auth: *auth
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 1
+
+    - name: Fetch a specific datastore
+      datastore_info:
+        auth: *auth
+        name: my-datastore
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 1
+          - result.objects.0.metadata.name == "my-datastore"
+          - result.objects.0.dsn == "postgresql://user:secret@host:port/new"
+          - result.objects.0.pool_size == 321
+
+    - name: Remove external datastore
+      datastore:
+        auth: *auth
+        name: my-datastore
+        state: absent
+
+    - name: Re-fetch all datastores
+      datastore_info:
+        auth: *auth
+      register: result
+
+    - assert:
+        that:
+          - result.objects | length == 0
+
+    - name: Try to fetch non-existing datastore
+      datastore_info:
+        auth: *auth
+        name: my-fictional-datastore
+      register: result
+
+    - assert:
+        that:
+          - result.objects == []
+
+    - name: Try to remove non-existing external datastore
+      datastore:
+        auth: *auth
+        name: my-fictional-datastore
+        state: absent
+
+    - assert:
+        that:
+          - result is not changed

--- a/tests/integration/scenario.times
+++ b/tests/integration/scenario.times
@@ -3,6 +3,7 @@ molecule/module_asset 131.65
 molecule/module_check 127.36
 molecule/module_cluster_role 137.09
 molecule/module_cluster_role_binding 135.98
+molecule/module_datastore 110.00
 molecule/module_entity 119.02
 molecule/module_event 139.63
 molecule/module_filter 125.77

--- a/tests/unit/module_utils/test_utils.py
+++ b/tests/unit/module_utils/test_utils.py
@@ -216,7 +216,7 @@ class TestDelete:
 
 class TestPut:
     @pytest.mark.parametrize(
-        "status", [100, 200, 202, 203, 204, 400, 401, 403, 500, 501],
+        "status", [100, 202, 203, 204, 400, 401, 403, 500, 501],
     )
     def test_abort_on_invalid_status(self, mocker, status):
         client = mocker.Mock()
@@ -226,9 +226,10 @@ class TestPut:
             utils.put(client, "/put", {"payload": "data"})
         client.put.assert_called_once_with("/put", {"payload": "data"})
 
-    def test_valid_put(self, mocker):
+    @pytest.mark.parametrize("status", [200, 201])
+    def test_valid_put(self, mocker, status):
         client = mocker.Mock()
-        client.put.return_value = http.Response(201, '{"put": "data"}')
+        client.put.return_value = http.Response(status, '{"put": "data"}')
 
         object = utils.put(client, "/put", {"payload": "data"})
 

--- a/tests/unit/modules/test_datastore.py
+++ b/tests/unit/modules/test_datastore.py
@@ -1,0 +1,272 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    errors, http, utils,
+)
+from ansible_collections.sensu.sensu_go.plugins.modules import datastore
+
+from .common.utils import (
+    AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args,
+)
+
+
+class TestSync(ModuleTestCase):
+    def test_absent_no_current_object(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = http.Response(404, "")
+
+        changed, object = datastore.sync(
+            "absent", client, "/list", "/resource", {}, False,
+        )
+
+        assert changed is False
+        assert object is None
+
+    def test_absent_no_current_object_check(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = http.Response(404, "")
+
+        changed, object = datastore.sync(
+            "absent", client, "/list", "/resource", {}, True,
+        )
+
+        assert changed is False
+        assert object is None
+
+    def test_absent_current_object_present(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = http.Response(200, '{}')
+        client.delete.return_value = http.Response(204, "")
+
+        changed, object = datastore.sync(
+            "absent", client, "/list", "/resource", {}, False,
+        )
+
+        assert changed is True
+        assert object is None
+        client.delete.assert_called_with("/resource")
+
+    def test_absent_current_object_present_check(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = http.Response(200, '{}')
+        client.delete.return_value = http.Response(204, "")
+
+        changed, object = datastore.sync(
+            "absent", client, "/list", "/resource", {}, True,
+        )
+
+        assert changed is True
+        assert object is None
+        client.delete.assert_not_called()
+
+    def test_present_current_object_differ(self, mocker):
+        client = mocker.Mock()
+        client.get.side_effect = (
+            http.Response(200, '{"spec": {"current": "data"}}'),
+            http.Response(200, '{"spec": {"new": "data"}}'),
+        )
+        client.put.return_value = http.Response(201, "")
+
+        changed, object = datastore.sync(
+            "present", client, "/list", "/resource", {"spec": {"my": "data"}},
+            False,
+        )
+
+        assert changed is True
+        assert {"spec": {"new": "data"}} == object
+        client.put.assert_called_once_with(
+            "/resource", {"spec": {"my": "data"}},
+        )
+
+    def test_present_current_object_differ_check(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = (
+            http.Response(200, '{"spec": {"current": "data"}}')
+        )
+
+        changed, object = datastore.sync(
+            "present", client, "/list", "/resource", {"spec": {"my": "data"}},
+            True,
+        )
+
+        assert changed is True
+        assert {"spec": {"my": "data"}} == object
+        client.put.assert_not_called()
+
+    def test_present_current_object_does_not_differ(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = (
+            http.Response(200, '{"spec": {"my": "data"}}')
+        )
+
+        changed, object = datastore.sync(
+            "present", client, "/list", "/resource", {"spec": {"my": "data"}},
+            False,
+        )
+
+        assert changed is False
+        assert {"spec": {"my": "data"}} == object
+        client.put.assert_not_called()
+
+    def test_present_current_object_does_not_differ_check(self, mocker):
+        client = mocker.Mock()
+        client.get.return_value = (
+            http.Response(200, '{"spec": {"my": "data"}}')
+        )
+
+        changed, object = datastore.sync(
+            "present", client, "/list", "/resource", {"spec": {"my": "data"}},
+            True,
+        )
+
+        assert changed is False
+        assert {"spec": {"my": "data"}} == object
+        client.put.assert_not_called()
+
+    def test_present_no_current_object_empty_backend(self, mocker):
+        client = mocker.Mock()
+        client.get.side_effect = (
+            http.Response(404, ""),
+            http.Response(200, "[]"),
+            http.Response(200, '{"spec": {"new": "data"}}'),
+        )
+        client.put.return_value = http.Response(201, "")
+
+        changed, object = datastore.sync(
+            "present", client, "/list", "/resource", {"spec": {"my": "data"}},
+            False,
+        )
+
+        assert changed is True
+        assert {"spec": {"new": "data"}} == object
+        client.put.assert_called_once_with(
+            "/resource", {"spec": {"my": "data"}},
+        )
+
+    def test_present_no_current_object_empty_backend_check(self, mocker):
+        client = mocker.Mock()
+        client.get.side_effect = (
+            http.Response(404, ""),
+            http.Response(200, "[]"),
+        )
+
+        changed, object = datastore.sync(
+            "present", client, "/list", "/resource", {"spec": {"my": "data"}},
+            True,
+        )
+
+        assert changed is True
+        assert {"spec": {"my": "data"}} == object
+        client.put.assert_not_called()
+
+    @pytest.mark.parametrize("check", [False, True])
+    def test_present_no_current_object_non_empty_backend(self, mocker, check):
+        client = mocker.Mock()
+        client.get.side_effect = (
+            http.Response(404, ""),
+            http.Response(200, "[{}]"),
+        )
+
+        with pytest.raises(errors.Error, match="already active"):
+            datastore.sync(
+                "present", client, "/list", "/resource",
+                {"spec": {"my": "data"}}, check,
+            )
+
+        client.put.assert_not_called()
+
+
+class TestDatastore(ModuleTestCase):
+    def test_minimal_datastore_parameters_present(self, mocker):
+        sync_mock = mocker.patch.object(datastore, "sync")
+        sync_mock.return_value = True, {}
+        set_module_args(
+            name="test_datastore",
+            dsn="my-dsn",
+        )
+
+        with pytest.raises(AnsibleExitJson):
+            datastore.main()
+
+        state, _client, list_path, resource_path, payload, check_mode = (
+            sync_mock.call_args[0]
+        )
+        assert state == "present"
+        assert resource_path == "/api/enterprise/store/v1/provider/test_datastore"
+        assert list_path == "/api/enterprise/store/v1/provider"
+        assert payload == dict(
+            type="PostgresConfig",
+            api_version="store/v1",
+            spec=dict(
+                metadata=dict(
+                    name="test_datastore",
+                ),
+                dsn="my-dsn",
+            ),
+        )
+        assert check_mode is False
+
+    def test_minimal_datastore_parameters_absent(self, mocker):
+        sync_mock = mocker.patch.object(datastore, "sync")
+        sync_mock.return_value = True, {}
+        set_module_args(
+            name="test_datastore",
+            state="absent",
+        )
+
+        with pytest.raises(AnsibleExitJson):
+            datastore.main()
+
+        state, _client, list_path, resource_path, _payload, check_mode = (
+            sync_mock.call_args[0]
+        )
+        assert state == "absent"
+        assert resource_path == "/api/enterprise/store/v1/provider/test_datastore"
+        assert list_path == "/api/enterprise/store/v1/provider"
+        assert check_mode is False
+
+    def test_all_datastore_parameters(self, mocker):
+        sync_mock = mocker.patch.object(datastore, "sync")
+        sync_mock.return_value = True, {}
+        set_module_args(
+            name="test_datastore",
+            dsn="my-dsn",
+            pool_size=543,
+        )
+
+        with pytest.raises(AnsibleExitJson):
+            datastore.main()
+
+        state, _client, list_path, resource_path, payload, check_mode = (
+            sync_mock.call_args[0]
+        )
+        assert state == "present"
+        assert resource_path == "/api/enterprise/store/v1/provider/test_datastore"
+        assert list_path == "/api/enterprise/store/v1/provider"
+        assert payload == dict(
+            type="PostgresConfig",
+            api_version="store/v1",
+            spec=dict(
+                metadata=dict(
+                    name="test_datastore",
+                ),
+                dsn="my-dsn",
+                pool_size=543,
+            ),
+        )
+        assert check_mode is False
+
+    def test_failure(self, mocker):
+        sync_mock = mocker.patch.object(utils, "sync")
+        sync_mock.side_effect = errors.Error("Bad error")
+        set_module_args(
+            name="test_datastore",
+            dsn="my-dsn",
+        )
+
+        with pytest.raises(AnsibleFailJson):
+            datastore.main()

--- a/tests/unit/modules/test_datastore_info.py
+++ b/tests/unit/modules/test_datastore_info.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import (
+    errors, utils,
+)
+from ansible_collections.sensu.sensu_go.plugins.modules import datastore_info
+
+from .common.utils import (
+    AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args,
+)
+
+
+class TestDatastoreInfo(ModuleTestCase):
+    def test_get_all_datastores(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = [dict(spec=1), dict(spec=2)]
+        set_module_args()
+
+        with pytest.raises(AnsibleExitJson) as context:
+            datastore_info.main()
+
+        _client, path = get_mock.call_args[0]
+        assert path == "/api/enterprise/store/v1/provider"
+        assert context.value.args[0]["objects"] == [1, 2]
+
+    def test_get_single_datastore(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = dict(spec=4)
+        set_module_args(name="sample-datastore")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            datastore_info.main()
+
+        _client, path = get_mock.call_args[0]
+        assert path == "/api/enterprise/store/v1/provider/sample-datastore"
+        assert context.value.args[0]["objects"] == [4]
+
+    def test_missing_single_datastore(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.return_value = None
+        set_module_args(name="sample-datastore")
+
+        with pytest.raises(AnsibleExitJson) as context:
+            datastore_info.main()
+
+        assert context.value.args[0]["objects"] == []
+
+    def test_failure(self, mocker):
+        get_mock = mocker.patch.object(utils, "get")
+        get_mock.side_effect = errors.Error("Bad error")
+        set_module_args(name="sample-datastore")
+
+        with pytest.raises(AnsibleFailJson):
+            datastore_info.main()


### PR DESCRIPTION
Datastore module and its info counterpart know how to deal with external datastores.

The payload that the Sensu storage API accepts is a bit different from the payload that core/v2 API endpoints expect, but we kept the user-facing interface similar to all other modules. This way, playbook authors can use their knowledge about existing modules when dealing with data storage.

Fixes #119 