### PR TITLE
Remove flaky tests that relied on external data

### DIFF
--- a/tests/integration/molecule/role_install_default/tests/test_installation.py
+++ b/tests/integration/molecule/role_install_default/tests/test_installation.py
@@ -6,32 +6,14 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import requests
-
-
-def latest_sensu_available():
-    """Access webpage to learn what the latest Sensu version is"""
-    res = requests.get("https://docs.sensu.io/sensu-go/latest", allow_redirects=False)
-    latest_url = res.headers.get("Location", "unknown").strip("/")
-    return latest_url.split("/")[-1]
-
-
-LATEST_VERSION = latest_sensu_available()
-
 
 def test_backend_installed(host):
     assert host.exists("sensu-backend")
-    assert "sensu-backend version {0}".format(LATEST_VERSION) in \
-           host.check_output("sensu-backend version")
 
 
 def test_agent_installed(host):
     assert host.exists("sensu-agent")
-    assert "sensu-agent version {0}".format(LATEST_VERSION) in \
-           host.check_output("sensu-agent version")
 
 
 def test_cli_installed(host):
     assert host.exists("sensuctl")
-    assert "sensuctl version {0}".format(LATEST_VERSION) in \
-           host.check_output("sensuctl version")


### PR DESCRIPTION
When we were determining the latest released version, we used an ugly hack that relied on docs.sensu.io redirect to hold the right version information.

Because Sensu changed the documentation site, our tests started to fail. And we have no one but ourselves to blame for that one.

We removed the ugly tests from the repository and while this reduces the comprehensiveness of the tests, we cannot do better right now since there is no canonical place to look for the latest version.