### PR TITLE
add namespace support to bonsai_asset

### DIFF
--- a/plugins/action/bonsai_asset.py
+++ b/plugins/action/bonsai_asset.py
@@ -31,7 +31,7 @@ def validate(name, args, required, typ):
 class ActionModule(ActionBase):
 
     _VALID_ARGS = frozenset(
-        ("auth", "name", "version", "rename", "labels", "annotations")
+        ("auth", "name", "version", "namespace", "rename", "labels", "annotations")
     )
 
     def run(self, _tmp=None, task_vars=None):
@@ -84,6 +84,9 @@ class ActionModule(ActionBase):
 
         if "auth" in args:
             asset_args["auth"] = args["auth"]
+
+        if "namespace" in args:
+            asset_args["namespace"] = args["namespace"]
 
         # Only add optional parameter if it is present in at least one source.
         for meta in ("labels", "annotations"):

--- a/tests/unit/action/test_bonsai_asset.py
+++ b/tests/unit/action/test_bonsai_asset.py
@@ -215,6 +215,25 @@ class TestBuildAssetArgs:
             builds=[],
         )
 
+    def test_namespace_passthrough(self, mocker):
+        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
+        bonsai_params.return_value = dict(
+            builds=[], labels=None, annotations=None,
+        )
+
+        result = bonsai_asset.ActionModule.build_asset_args(dict(
+            namespace='default',
+            name="test/asset",
+            version="1.2.3",
+        ))
+
+        assert result == dict(
+            name="test/asset",
+            namespace='default',
+            state="present",
+            builds=[],
+        )
+
     def test_fail_bonsai(self, mocker):
         bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
         bonsai_params.side_effect = errors.BonsaiError("Bonsai bad")


### PR DESCRIPTION
nice work on the collection!

I came across this error when using `bonsai_asset` with a non-"default" namespace. This is hopefully the correct fix.