### PR TITLE
Prepare collection for 1.1.0 release

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,22 @@
 Release notes
 =============
 
+Version 1.1 -- Hello Sensu Go 5.16
+----------------------------------
+
+This is the first release that supports installing Sensu Go 5.16.
+
+**New features:**
+
+* Support for Sensu Go 5.16 initialization in backend role.
+* Support for external datastore management using *datastore* and
+  *datastore_info* modules.
+
+**Bug fixes:**
+
+* Reintroduce namespace support to *bonsai_asset* module (thanks, @jakeo)
+
+
 Version 1.0 -- Rising From The Ashes
 ------------------------------------
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: sensu
 name: sensu_go
-version: 1.0.0
+version: 1.1.0
 
 authors:
   - Paul Arthur <paul.arthur@flowerysong.com> (@flowerysong)


### PR DESCRIPTION
Update release notes and collection metadata in preparation for upcoming 1.1 release.

~Depends on #130~ ~We will fix #130 in a separate patch release since getting support for Sensu Go 5.16 out is semi-urgent.~ Not sure how I managed to miss the #130 update, but the work there was ready.