### PR TITLE
Fix bonsai_asset parameter validation on python 2

### DIFF
--- a/plugins/action/bonsai_asset.py
+++ b/plugins/action/bonsai_asset.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 
 import json
 
+from ansible.module_utils.six import text_type
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash
 
@@ -65,9 +66,15 @@ class ActionModule(ActionBase):
         # We only validate arguments that we use. We let the asset module
         # validate the rest (like auth data).
 
-        validate("name", args, required=True, typ=str)
-        validate("version", args, required=True, typ=str)
-        validate("rename", args, required=False, typ=str)
+        # Next three string validations might seem strange at first, but there
+        # is a reason for this strangenes. On python 2, we should consider
+        # string to be instance of str or unicode. On python 3, strings are
+        # always instances of str. In order to avoid having a separate
+        # validate calls for python 2 and python 3, we always pass a pair of
+        # types that just happen to be the same on python 3.
+        validate("name", args, required=True, typ=(str, text_type))
+        validate("version", args, required=True, typ=(str, text_type))
+        validate("rename", args, required=False, typ=(str, text_type))
         validate("labels", args, required=False, typ=dict)
         validate("annotations", args, required=False, typ=dict)
 

--- a/tests/unit/action/test_bonsai_asset.py
+++ b/tests/unit/action/test_bonsai_asset.py
@@ -56,6 +56,12 @@ class TestValidateArguments:
             labels={}, annotations={},
         ))
 
+    def test_valid_unicode_strings_python2(self):
+        bonsai_asset.ActionModule.validate_arguments(dict(
+            name=u"abc", version=u"1.2.3", rename=u"def",
+            labels={}, annotations={},
+        ))
+
     def test_invalid_name(self):
         with pytest.raises(errors.Error, match="name"):
             bonsai_asset.ActionModule.validate_arguments(dict(


### PR DESCRIPTION
When Ansible is running on python 2, it converts all strings into unicode type when loading YAML files. And because our validation function did not account for this, all hell break loose on python 2.

This commit introduces a simple fix for this: instead of checking for a fixed type, we use Ansible-provided python-version-specific wrappers for a string type.

Note that we could also use unicode type directly, but since Ansible developers already maintain a cross-version implementation, we might as well use it.

Fixes #134 