### PR TITLE
Tighten static analysis

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,22 @@
+# This configuration mirrors the configuration that is used when linting
+# collections on import into Ansible Galaxy.
+
+# TODO(@tadeboro): Some of our lines are almost twice the optimal reading
+# length of 60-80 chars. It would be great to get line lengths down to 79, but
+# this is not feasible at the moment since we have cca. 300 lines that are
+# longer. What we need is a way of preventing new long lines of getting into
+# the codebase, which means running flake8 with stricter rules on changed
+# lines only.
+
+[flake8]
+max-line-length = 144
+max-doc-length = 92
+
+exclude =
+    # ansible-test creates all sorts of temporary stuff that we do not care
+    # about.
+    tests/output
+
+per-file-ignores =
+    # Modules have their imports listed after the metadata.
+    plugins/modules/*.py:E402

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ requirements:  ## Install development requirements
 
 .PHONY: sanity
 sanity:  ## Run sanity tests
+	flake8
 	ansible-test sanity --python $(python_version)
 
 .PHONY: units

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ requirements:  ## Install development requirements
 .PHONY: sanity
 sanity:  ## Run sanity tests
 	flake8
+	ansible-lint -p roles/*
 	ansible-test sanity --python $(python_version)
 
 .PHONY: units

--- a/plugins/action/bonsai_asset.py
+++ b/plugins/action/bonsai_asset.py
@@ -6,8 +6,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import json
-
 from ansible.module_utils.six import text_type
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash

--- a/plugins/modules/check.py
+++ b/plugins/modules/check.py
@@ -214,7 +214,7 @@ def validate_module_params(module):
             proxy_requests.get('splay_coverage') is None):
         module.fail_json(msg='splay is true but all of the following are missing: splay_coverage')
 
-    if params['state'] is 'present' and not (params['interval'] or params['cron']):
+    if params['state'] == 'present' and not (params['interval'] or params['cron']):
         module.fail_json(msg='one of the following is required: interval, cron')
 
 

--- a/plugins/modules/namespace.py
+++ b/plugins/modules/namespace.py
@@ -55,7 +55,7 @@ object:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.basic import AnsibleModule
 
 
 from ansible_collections.sensu.sensu_go.plugins.module_utils import (

--- a/plugins/modules/namespace_info.py
+++ b/plugins/modules/namespace_info.py
@@ -48,7 +48,7 @@ objects:
   type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.sensu.sensu_go.plugins.module_utils import (
     arguments, errors, utils,
 )

--- a/roles/backend/tasks/main.yml
+++ b/roles/backend/tasks/main.yml
@@ -71,10 +71,11 @@
   tags: [run_backend]
 
 - name: Check for sensu-backend init command
-  shell:
+  command:
     cmd: sensu-backend init -h
   register: init_command_test
   failed_when: false  # Never fail, we just want to know if init exists.
+  changed_when: false  # Displaying help is read-only operation.
 
 - name: Initialize backend
   command:

--- a/roles/install/tasks/apt/install.yml
+++ b/roles/install/tasks/apt/install.yml
@@ -1,8 +1,11 @@
 ---
+# Why did we kill the 403 (package installs should not use latest) check?
+# Because we really do want to be able to upgrade the packages to the latest
+# stable version.
 - name: Install latest component version
   apt:
     name: "{{ item }}"
-    state: latest
+    state: latest  # noqa 403
   when: version == "latest"
   loop: "{{ components }}"
 

--- a/roles/install/tasks/yum/install.yml
+++ b/roles/install/tasks/yum/install.yml
@@ -1,8 +1,11 @@
 ---
+# Why did we kill the 403 (package installs should not use latest) check?
+# Because we really do want to be able to upgrade the packages to the latest
+# stable version.
 - name: Install latest component version
   yum:
     name: "{{ item }}"
-    state: latest
+    state: latest  # noqa 403
   when: version == "latest"
   loop: "{{ components }}"
 

--- a/sanity.requirements
+++ b/sanity.requirements
@@ -1,3 +1,4 @@
+ansible-lint
 flake8
 pycodestyle
 pylint

--- a/sanity.requirements
+++ b/sanity.requirements
@@ -1,3 +1,4 @@
+flake8
 pycodestyle
 pylint
 rstcheck

--- a/tests/unit/modules/test_event.py
+++ b/tests/unit/modules/test_event.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import pytest
 
 from ansible_collections.sensu.sensu_go.plugins.module_utils import (
-    errors, http, utils,
+    errors, http,
 )
 from ansible_collections.sensu.sensu_go.plugins.modules import event
 

--- a/tests/unit/modules/test_filter.py
+++ b/tests/unit/modules/test_filter.py
@@ -53,7 +53,7 @@ class TestFilter(ModuleTestCase):
             annotations={'playbook': 12345},
         )
 
-        with pytest.raises(AnsibleExitJson) as context:
+        with pytest.raises(AnsibleExitJson):
             filter.main()
 
         state, _client, path, payload, check_mode = sync_mock.call_args[0]

--- a/tests/unit/modules/test_tessen.py
+++ b/tests/unit/modules/test_tessen.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import pytest
 
 from ansible_collections.sensu.sensu_go.plugins.module_utils import (
-    errors, http, utils
+    errors, http,
 )
 from ansible_collections.sensu.sensu_go.plugins.modules import tessen
 


### PR DESCRIPTION
Import process on Ansible Galaxy runs some static checks on the code that `ansible-test sanity` does not. Changes in this PR add those check to our `sanity` make target.