### PR TITLE
Strip empty lines from Sensu configuration files

### DIFF
--- a/roles/agent/templates/agent.yml.j2
+++ b/roles/agent/templates/agent.yml.j2
@@ -9,18 +9,18 @@
 {% if not agent_config or "backend-url" not in agent_config %}
 backend-url:
 {{ agent_backend_urls | to_nice_yaml }}
-{% endif %}
+{% endif -%}
 
 {% if agent_trusted_ca_file is defined and
       not (agent_config and "trusted-ca-file" in agent_config) %}
 trusted-ca-file: /etc/sensu/sensu-agent-trusted-ca.crt
-{% endif %}
+{% endif -%}
 
 {% if agent_trusted_ca_file is defined or agent_config and
       ("trusted-ca-file" in agent_config and
        not "insecure-skip-tls-verify" in agent_config) %}
 insecure-skip-tls-verify: false
-{% endif %}
+{% endif -%}
 
 {% if agent_config %}
 {{ agent_config | to_nice_yaml }}

--- a/roles/backend/templates/backend.yml.j2
+++ b/roles/backend/templates/backend.yml.j2
@@ -5,7 +5,7 @@
 
 {% if not backend_config or "state-dir" not in backend_config %}
 state-dir: "/var/lib/sensu/sensu-backend"
-{% endif %}
+{% endif -%}
 
 {% set secure_etcd = etcd_trusted_ca_file is defined or etcd_cert_file is defined or
         etcd_key_file is defined or etcd_peer_cert_file is defined or
@@ -13,111 +13,111 @@ state-dir: "/var/lib/sensu/sensu-backend"
 {% if secure_etcd and
       (not backend_config or "etcd-listen-client-urls" not in backend_config) %}
 etcd-listen-client-urls: "https://localhost:2379"
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or "etcd-listen-peer-urls" not in backend_config) %}
 etcd-listen-peer-urls: "https://localhost:2380"
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or "etcd-initial-cluster" not in backend_config) %}
 etcd-initial-cluster: "default=https://localhost:2380"
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or
        "etcd-initial-advertise-peer-urls" not in backend_config) %}
 etcd-initial-advertise-peer-urls: "https://localhost:2380"
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or "etcd-cert-file" not in backend_config) %}
 etcd-cert-file: "/etc/sensu/etcd-client.crt"
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or "etcd-key-file" not in backend_config) %}
 etcd-key-file: "/etc/sensu/etcd-client.key"
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or "etcd-client-cert-auth" not in backend_config) %}
 etcd-client-cert-auth: true
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or "etcd-trusted-ca-file" not in backend_config) %}
 etcd-trusted-ca-file: "/etc/sensu/etcd-client-ca.crt"
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or "etcd-peer-cert-file" not in backend_config) %}
 etcd-peer-cert-file: "/etc/sensu/etcd-peer.crt"
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or "etcd-peer-key-file" not in backend_config) %}
 etcd-peer-key-file: "/etc/sensu/etcd-peer.key"
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or
        "etcd-peer-client-cert-auth" not in backend_config) %}
 etcd-peer-client-cert-auth: true
-{% endif %}
+{% endif -%}
 
 {% if secure_etcd and
       (not backend_config or
        "etcd-peer-trusted-ca-file" not in backend_config) %}
 etcd-peer-trusted-ca-file: "/etc/sensu/etcd-peer-ca.crt"
-{% endif %}
+{% endif -%}
 
 {% set secure_api = api_cert_file is defined or api_key_file is defined or
         api_trusted_ca_file is defined %}
 {% if secure_api and
       (not backend_config or "cert-file" not in backend_config) %}
 cert-file: "/etc/sensu/api.crt"
-{% endif %}
+{% endif -%}
 
 {% if secure_api and
       (not backend_config or "key-file" not in backend_config) %}
 key-file: "/etc/sensu/api.key"
-{% endif %}
+{% endif -%}
 
 {% if secure_api and
       (not backend_config or
        "insecure-skip-tls-verify" not in backend_config) %}
 insecure-skip-tls-verify: false
-{% endif %}
+{% endif -%}
 
 {% if secure_api and
       (not backend_config or "trusted-ca-file" not in backend_config) %}
 trusted-ca-file: "/etc/sensu/api-ca.crt"
-{% endif %}
+{% endif -%}
 
 {% if secure_api and
       (not backend_config or
        "insecure-skip-tls-verify" not in backend_config) %}
 insecure-skip-tls-verify: false
-{% endif %}
+{% endif -%}
 
 {% if secure_api and
       (not backend_config or "api-url" not in backend_config) %}
 api-url: "https://localhost:8080"
-{% endif %}
+{% endif -%}
 
 {% set secure_dashboard = dashboard_cert_file is defined or
         dashboard_key_file is defined %}
 {% if secure_dashboard and
       (not backend_config or "dashboard-cert-file" not in backend_config) %}
 dashboard-cert-file: "/etc/sensu/dashboard.crt"
-{% endif %}
+{% endif -%}
 
 {% if secure_dashboard and
       (not backend_config or "dashboard-key-file" not in backend_config) %}
 dashboard-key-file: "/etc/sensu/dashboard.key"
-{% endif %}
+{% endif -%}
 
 {% if backend_config %}
 {{ backend_config | to_nice_yaml }}


### PR DESCRIPTION
While it is true that the generated configuration files should not be modified manually, they might still get inspected from time to time. And in those cases, having a nice, readable configuration file can
make a significant difference in usability.

But because we do not want to bundle all our template conditional logic into one continuous block that looks like a core dump, we implemented the cleanup by using Jinja's trim modifiers to code blocks.

This way we can almost have a cake and eat it too: the template is readable from the developer's perspective and the generated configuration is concise and clean.