### PR TITLE
Add upper version limit for coverage package

### DIFF
--- a/units.requirements
+++ b/units.requirements
@@ -1,4 +1,4 @@
-coverage
+coverage < 5
 mock
 pytest
 pytest-mock


### PR DESCRIPTION
Unfortunately, ansible-test is not compatible with the latest stable coverage package. As a temporary workaround, we now force the coverage version 4.x.