### PR TITLE
Make sure we run all integration tests

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -26,4 +26,7 @@ $(modules) $(roles) $(actions):
 # CI stuff - partitioning logic ("true" is the value of the $CI variable)
 .PHONY: true
 true:
+	cut -d" " -f1 scenario.times | sort > times.tmp
+	find molecule/ -mindepth 1 -maxdepth 1 -type d | sort > dirs.tmp
+	diff times.tmp dirs.tmp
 	$(MAKE) $$(python partition.py scenario.times)


### PR DESCRIPTION
Because our CI runs only tests that are listed in the file with scenario run times, we need to make sure that when a new test is created, it is also timed and timings committed.

The check for this is really simple: we list all of the scenarios in the molecule directory and compare the output with the contents of the timings file. If there is anything different, we abort the run and fail the test.