### PR TITLE
Prepare collection for 1.2.0 release

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,18 @@
 Release notes
 =============
 
+Version 1.2.0 -- Building support for builds
+--------------------------------------------
+
+This release adds support for specifying builds when installing various Sensu
+Go components.
+
+**New features:**
+
+* Add *build* variable to the *install* role that further pins down the
+  package version that gets installed.
+
+
 Version 1.1.1 -- Python 2 is Still a Thing
 ------------------------------------------
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,10 @@ Version 1.1.1 -- Python 2 is Still a Thing
 This is a bugfix release that makes sure the Sensu collection is working when
 Ansible control node uses Python 2.
 
+**New features:**
+
+* Add support for RHEL 7 to the install role (thanks, @danragnar).
+
 **Bug fixes:**
 
 * Accept *str* and *unicode* instance as a valid string in *bonsai_asset*

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: sensu
 name: sensu_go
-version: 1.1.1
+version: 1.2.0
 
 authors:
   - Paul Arthur <paul.arthur@flowerysong.com> (@flowerysong)


### PR DESCRIPTION
This PR also includes some changes that should be part of the 1.1.1 release, but I forgot to include them. I did split them into a separate commit in order to keep things as clean as possible.