### PR TITLE
Fix apt package installation on fresh instances

### DIFF
--- a/roles/install/tasks/apt/prepare.yml
+++ b/roles/install/tasks/apt/prepare.yml
@@ -2,6 +2,10 @@
 - name: Include distro-specific vars ({{ ansible_distribution }})
   include_vars: file='{{ ansible_distribution }}.yml'
 
+- name: Update apt cache (ensure we have package index)
+  apt:
+    update_cache: true
+
 - name: Install utility packages
   apt:
     name:


### PR DESCRIPTION
Up until now, the installation role assumed that the apt's package cache is at least partially up to date. It turned out that this assumption falls flat on its face in the world of cloud images.

Changes in this commit force a cache refresh before any of the preparation processes are started. It may seem a bit expensive to do this at first, but the performance impact is actually negligible since
the update happens anyway when we add a new repo.