### PR TITLE
Add API key authentication support

### DIFF
--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -7,31 +7,114 @@ the same pattern as much as possible.
 The API of each module is composed of two parts. The *auth* parameter contains
 the pieces of information that are related to the Sensu Go backend that the
 module is connecting to. All other parameters hold the information related to
-the resource that we are operating on. A typical task would look like this:
+the resource that we are operating on.
+
+
+Authentication parameters
+-------------------------
+
+Each module has an *auth* parameter that holds the following information about
+the Sensu Go backend:
+
+1. The **url** key holds the address of the Sensu Go backend. If this key is
+   not present in the task's definition, Ansible will consult the *SENSU_URL*
+   environment variable and, if the variable is not set, use the default value
+   of ``http://localhost:8080``.
+2. The **user** and **password** keys contain the credentials that the module
+   will use when connecting to the backend. It not present, Ansible will try
+   to look up the *SENSU_USER* and *SENSU_PASSWORD* environment variables,
+   falling back to the default values of ``admin`` and ``P@ssw0rd!``.
+3. The **api_key** field should contain an `API key`_ that module will use to
+   authenticate with the backend. If not present, Ansible will try to use the
+   value stored in the *SENSU_API_KEY*.
+
+.. _API key:
+   https://docs.sensu.io/sensu-go/latest/guides/use-apikey-feature/
+
+.. note::
+
+   The API key authentication is only available in Sensu Go 5.15 or newer.
+
+When Ansible tries to connect to the Sensu Go backend, it will try to
+authenticate using the API key. If the *api_key* is not set, Ansible will
+fallback to using the *user* and *password* values for authentication. What
+this basically means is that there are two valid sets of *auth* parameters:
+
+.. code-block:: yaml
+
+   - name: Use API key authentication
+     asset:
+       auth:
+         url: http://my.sensu.host:8765
+         api_key: 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
+       # Other asset parameters here
+
+   - name: Use user and password authentication
+     asset:
+       auth:
+         url: http://my.sensu.host:8765
+         user: my-user
+         password: my-password
+       # Other asset parameters here
+
+It is not an error to specify all four parameters when writing an Ansible
+task, but the *user* and *password* fields are ignored in this case:
+
+.. code-block:: yaml
+
+   - name: Use API key authentication and ignore user and password values
+     asset:
+       auth:
+         url: http://my.sensu.host:8765
+         user: my-user          # IGNORED
+         password: my-password  # IGNORED
+         api_key: 7f63b5bc-41f4-4b3e-b59b-5431afd7e6a2
+       # Other asset parameters here
+
+.. note::
+
+   If the *api_key* parameter is set to an invalid value, Ansible will **NOT**
+   fallback to the second method of authentication. Instead, it will report
+   an error and abort the run.
+
+
+Managing Sensu Go resources
+---------------------------
+
+There are three things we can do using the Sensu Go Ansible modules:
+
+1. Make sure that the specified resource is present on the backend.
+2. Make sure that the named resource is not present on the backend.
+3. List all currently available resources on the backend.
+
+.. note::
+
+   We left out the *auth* parameter from the following examples in order to
+   keep them short and readable.
+
+A typical task for creating (and by *creating* we mean *making sure it
+exists*) a resource on the backend would look like this:
 
 .. code-block:: yaml
 
    - name: Make sure asset is present
      asset:
-       auth:
-         url: http://sensu.host.com:8080
-         user: my-user
-         password: pass
        namespace: my-namespace
        name: my-asset-name
-       builds: ...
+       # Other asset parameters go here
 
-If we would like to remove a certain resource from the Sensu backend, we can
-write a task and set its *state* parameter to ``absent``:
+We need to specify the resource's name and decide into what namespace to place
+it if the resource is not a cluster-wide resource. There are a few exceptions
+to this rule, but not many.
+
+If we would like to remove a certain resource from the Sensu backend (and by
+*remove* we mean *make sure it is not present*), we can write a task and set
+its *state* parameter to ``absent``:
 
 .. code-block:: yaml
 
    - name: Make sure asset is absent
      asset:
-       auth:
-         url: http://sensu.host.com:8080
-         user: my-user
-         password: pass
        namespace: my-namespace
        name: my-asset-name
        state: absent
@@ -44,10 +127,6 @@ instance *asset* and *asset_info* modules.
 
    - name: Fetch a list of all assets
      asset_info:
-       auth:
-         url: http://sensu.host.com:8080
-         user: my-user
-         password: pass
        namespace: my-namespace
      register: result
 
@@ -59,10 +138,6 @@ previous task:
 
    - name: Fetch a specific asset
      asset_info:
-       auth:
-         url: http://sensu.host.com:8080
-         user: my-user
-         password: pass
        namespace: my-namespace
        name: my-asset-name
      register: result
@@ -75,10 +150,6 @@ This makes it easy to write conditional tasks using next pattern:
 
    - name: Fetch a specific asset
      asset_info:
-       auth:
-         url: http://sensu.host.com:8080
-         user: my-user
-         password: pass
        namespace: my-namespace
        name: my-asset-name
      register: result
@@ -94,10 +165,6 @@ Of course, you can also loop over the result using a *loop* construct:
 
    - name: Fetch a list of all assets
      asset_info:
-       auth:
-         url: http://sensu.host.com:8080
-         user: my-user
-         password: pass
        namespace: my-namespace
      register: result
 
@@ -106,41 +173,15 @@ Of course, you can also loop over the result using a *loop* construct:
        msg: "{{ item.metadata.name }}: {{ item.builds | length }}"
      loop: result.objects
 
-For convenience, modules also consult some environment variables when getting
-parameter values. This allows us to remove the *auth* and *namespace*
-parameters from task definitions and define them only once:
-
-.. code-block:: yaml
-
-   ---
-   - hosts: all
-     collections: [ sensu.sensu_go ]
-     environment:
-       SENSU_URL: http://sensu.host.com:8080
-       SENSU_USER: my-user
-       SENSU_PASSWORD: pass
-       SENSU_NAMESPACE: my-namespace
-
-     tasks:
-       - name: Asset task
-         asset:
-           name: my-asset
-           # More parameters here
-
-       - name: Check task
-         check:
-           name: my-check
-           # More parameters here
-
-       # More tasks here
-
 Reference material for each module contains documentation on what parameters
 certain modules accept and what values they expect those parameters to be.
 
 
+Module reference
+----------------
+
 .. toctree::
    :glob:
    :maxdepth: 1
-   :caption: Available modules
 
    modules/*

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -20,6 +20,7 @@ options:
           - The username to use for connecting to the Sensu API.
             If this is not set the value of the SENSU_USER environment
             variable will be checked.
+          - This parameter is ignored if the I(auth.api_key) parameter is set.
         type: str
         default: admin
       password:
@@ -27,6 +28,7 @@ options:
           - The Sensu user's password.
             If this is not set the value of the SENSU_PASSWORD environment
             variable will be checked.
+          - This parameter is ignored if the I(auth.api_key) parameter is set.
         type: str
         default: P@ssw0rd!
       url:
@@ -36,4 +38,15 @@ options:
             will be checked.
         type: str
         default: http://localhost:8080
+      api_key:
+        description:
+          - The API key that should be used when authenticating. If this is
+            not set, the value of the SENSU_API_KEY environment variable will
+            be checked.
+          - This replaces I(auth.user) and I(auth.password) parameters.
+          - For more information about the API key, refer to the official
+            Sensu documentation at
+            U(https://docs.sensu.io/sensu-go/latest/guides/use-apikey-feature/).
+        type: str
+        version_added: "1.3"
 """

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -29,6 +29,9 @@ SHARED_SPECS = dict(
                 default="http://localhost:8080",
                 fallback=(env_fallback, ["SENSU_URL"]),
             ),
+            api_key=dict(
+                fallback=(env_fallback, ["SENSU_API_KEY"]),
+            ),
         ),
     ),
     state=dict(
@@ -85,4 +88,6 @@ def get_mutation_payload(source, *wanted_params):
 
 
 def get_sensu_client(auth):
-    return client.Client(auth["url"], auth["user"], auth["password"])
+    return client.Client(
+        auth["url"], auth["user"], auth["password"], auth["api_key"],
+    )

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -7,25 +7,52 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible_collections.sensu.sensu_go.plugins.module_utils import (
-    errors, http,
+    errors, http, utils,
 )
 
 
 class Client:
-    def __init__(self, address, username, password):
+    def __init__(self, address, username, password, api_key):
         self.address = address.rstrip("/")
         self.username = username
         self.password = password
+        self.api_key = api_key
 
-        self._token = None  # Login when/if required
+        self._auth_header = None  # Login when/if required
 
     @property
-    def token(self):
-        if not self._token:
-            self._token = self._login()
-        return self._token
+    def auth_header(self):
+        if not self._auth_header:
+            self._auth_header = self._login()
+        return self._auth_header
 
     def _login(self):
+        if self.api_key:
+            return self._api_key_login()
+        return self._username_password_login()
+
+    def _api_key_login(self):
+        # We check the API key validity by using it to fetch its metadata from
+        # the backend. This should also take care of validating if the backend
+        # even supports the API key authentication.
+
+        url = "{0}{1}".format(self.address, utils.build_core_v2_path(
+            None, "apikeys", self.api_key,
+        ))
+        headers = dict(Authorization="Key {0}".format(self.api_key))
+
+        resp = http.request("GET", url, headers=headers)
+        if resp.status != 200:
+            raise errors.SensuError(
+                "The API key {0}...{1} seems to be invalid or the backend "
+                "does not support the API key authentication".format(
+                    self.api_key[:5], self.api_key[-5:],
+                )
+            )
+
+        return headers
+
+    def _username_password_login(self):
         resp = http.request(
             "GET", "{0}/auth".format(self.address), force_basic_auth=True,
             url_username=self.username, url_password=self.password,
@@ -46,11 +73,13 @@ class Client:
                 "Authentication call did not return access token",
             )
 
-        return resp.json["access_token"]
+        return dict(
+            Authorization="Bearer {0}".format(resp.json["access_token"]),
+        )
 
     def request(self, method, path, payload=None):
         url = self.address + path
-        headers = {"Authorization": "Bearer {0}".format(self.token)}
+        headers = self.auth_header
 
         return http.request(method, url, payload=payload, headers=headers)
 

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -1,7 +1,8 @@
 modules   := $(wildcard molecule/module_*)
 roles     := $(wildcard molecule/role_*)
 actions   := $(wildcard molecule/action_*)
-scenarios := $(modules) $(roles) $(actions)
+misc      := $(wildcard molecule/misc_*)
+scenarios := $(modules) $(roles) $(actions) $(misc)
 
 # Make sure ansible can find our collection without having to install it.
 export ANSIBLE_COLLECTIONS_PATHS ?= $(realpath $(CURDIR)/../../../../..)
@@ -19,8 +20,11 @@ roles: $(roles)
 .PHONY: actions
 actions: $(actions)
 
-.PHONY: $(modules) $(roles) $(actions)
-$(modules) $(roles) $(actions):
+.PHONY: misc
+misc: $(misc)
+
+.PHONY: $(scenarios)
+$(scenarios):
 	molecule -c base.yml test --parallel -s $(notdir $@)
 
 # CI stuff - partitioning logic ("true" is the value of the $CI variable)

--- a/tests/integration/molecule/misc_api_authentication/molecule.yml
+++ b/tests/integration/molecule/misc_api_authentication/molecule.yml
@@ -1,0 +1,16 @@
+platforms:
+  - name: v5.15.0
+    image: xlabsi/sensu:5.15.0
+    groups: [ has_api_key_support ]
+    pre_build_image: true
+    pull: true
+    override_command: false
+  - name: v5.14.2
+    image: xlabsi/sensu:5.14.2
+    groups: [ no_api_key_support ]
+    pre_build_image: true
+    pull: true
+    command: >
+      sensu-backend start
+        --state-dir /var/lib/sensu/sensu-backend/etcd1
+        --log-level debug

--- a/tests/integration/molecule/misc_api_authentication/playbook.yml
+++ b/tests/integration/molecule/misc_api_authentication/playbook.yml
@@ -1,0 +1,260 @@
+---
+- name: Prepare new backend
+  hosts: has_api_key_support
+  gather_facts: no
+
+  tasks:
+    - name: Configure sensuctl
+      command:
+        cmd: >
+          sensuctl configure
+          --non-interactive
+          --url http://localhost:8080
+          --username admin
+          --password P@ssw0rd!
+          --namespace default
+
+    - name: Create API key
+      command:
+        cmd: sensuctl api-key grant admin
+      register: api_key_result
+
+    - name: Store API key
+      set_fact:
+        api_key: "{{ api_key_result.stdout | regex_search('[^/]+$') }}"
+
+    - name: Change default admin password for tests
+      command:
+        cmd: >
+          sensuctl user change-password admin
+          --current-password 'P@ssw0rd!'
+          --new-password insecure
+
+
+- name: Test against a new backend
+  hosts: has_api_key_support
+  collections:
+    - sensu.sensu_go
+  gather_facts: no
+
+  tasks:
+    - name: Fail with invalid password
+      mutator:
+        auth:
+          user: admin
+          password: not-a-password
+          url: http://localhost:8080
+        name: my_mutator
+        command: sensu-influxdb-mutator
+        timeout: 30
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "'Authentication' in result.msg"
+
+    - name: Fail with bad username
+      asset_info:
+        auth:
+          user: not-a-valid-user
+          password: insecure
+          url: http://localhost:8080
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "'Authentication' in result.msg"
+
+    - name: Fail with bad API token
+      hook:
+        auth:
+          api_key: not-a-valid-api-key
+          url: http://localhost:8080
+        name: restart_nginx
+        command: sudo systemctl start nginx
+        timeout: 60
+        stdin: false
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "'API key' in result.msg"
+
+    - name: Fail with bad API token even if username/password would be OK
+      hook:
+        auth:
+          api_key: not-a-valid-api-key
+          user: admin
+          password: insecure
+          url: http://localhost:8080
+        name: restart_nginx
+        command: sudo systemctl start nginx
+        timeout: 60
+        stdin: false
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "'API key' in result.msg"
+
+    - name: Authenticate with a valid user/pass combination
+      asset:
+        auth:
+          user: admin
+          password: insecure
+          url: http://localhost:8080
+        name: my_asset
+        builds:
+          - url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
+            sha512: 518e7c17cf670393045bff4af318e1d35955bfde166e9ceec2b469109252f79043ed133241c4dc96501b6636a1ec5e008ea9ce055d1609865635d4f004d7187b
+      register: result
+
+    - assert:
+        that:
+          - result is success
+
+    - name: Authenticate with a valid API key
+      asset_info:
+        auth:
+          api_key: "{{ api_key }}"
+          url: http://localhost:8080
+      register: result
+
+    - assert:
+        that:
+          - result is success
+
+    - name: Authenticate with a valid API key and ignore user/password
+      asset_info:
+        auth:
+          api_key: "{{ api_key }}"
+          user: not-a-valid-user
+          password: not-a-password
+          url: http://localhost:8080
+      register: result
+
+    - assert:
+        that:
+          - result is success
+
+
+- name: Prepare old backend
+  hosts: no_api_key_support
+  gather_facts: no
+
+  tasks:
+    - name: Configure sensuctl
+      command:
+        cmd: >
+          sensuctl configure
+          --non-interactive
+          --url http://localhost:8080
+          --username admin
+          --password P@ssw0rd!
+          --namespace default
+
+    - name: Change default admin password for tests
+      command:
+        cmd: >
+          sensuctl user change-password admin
+          --current-password 'P@ssw0rd!'
+          --new-password insecure
+
+
+- name: Test against an old backend
+  hosts: no_api_key_support
+  collections:
+    - sensu.sensu_go
+  gather_facts: no
+
+  tasks:
+    - name: Fail with invalid password
+      mutator:
+        auth:
+          user: admin
+          password: not-a-password
+          url: http://localhost:8080
+        name: my_mutator
+        command: sensu-influxdb-mutator
+        timeout: 30
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "'Authentication' in result.msg"
+
+    - name: Fail with bad username
+      asset_info:
+        auth:
+          user: not-a-valid-user
+          password: insecure
+          url: http://localhost:8080
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "'Authentication' in result.msg"
+
+    - name: Fail with API token
+      hook:
+        auth:
+          api_key: not-a-valid-api-key
+          url: http://localhost:8080
+        name: restart_nginx
+        command: sudo systemctl start nginx
+        timeout: 60
+        stdin: false
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "'API key' in result.msg"
+
+    - name: Fail with bad API token even if username/password would be OK
+      hook:
+        auth:
+          api_key: not-a-valid-api-key
+          user: admin
+          password: insecure
+          url: http://localhost:8080
+        name: restart_nginx
+        command: sudo systemctl start nginx
+        timeout: 60
+        stdin: false
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+          - "'API key' in result.msg"
+
+    - name: Authenticate with a valid user/pass combination
+      asset:
+        auth:
+          user: admin
+          password: insecure
+          url: http://localhost:8080
+        name: my_asset
+        builds:
+          - url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
+            sha512: 518e7c17cf670393045bff4af318e1d35955bfde166e9ceec2b469109252f79043ed133241c4dc96501b6636a1ec5e008ea9ce055d1609865635d4f004d7187b
+      register: result
+
+    - assert:
+        that:
+          - result is success

--- a/tests/integration/scenario.times
+++ b/tests/integration/scenario.times
@@ -1,4 +1,5 @@
 molecule/action_bonsai_asset 130.82
+molecule/misc_api_authentication 71.23
 molecule/module_asset 131.65
 molecule/module_check 127.36
 molecule/module_cluster_role 137.09


### PR DESCRIPTION
Sensu Go supports API key authentication since version 5.15.0 and it is about time we also add it as a valid method of authentication.

In order not to break the backward compatibility, we made the API key optional. If the API key is not present in the parameters, we proceed with the username and password login. If the API key is set, we validate it and in the case of failure report the error back to the user.

Note that if the API key is present nut invalid, we do not try to authenticate using username and password. We wrote the code this way on purpose, since silently ignoring authentication failure with something that the user believes is valid is not an option.