### PR TITLE
Catch errors from all user API queries

### DIFF
--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -122,7 +122,11 @@ def main():
     path = utils.build_core_v2_path(None, 'users', module.params['name'])
     state = module.params['state']
 
-    remote_object = utils.get(client, path)
+    try:
+        remote_object = utils.get(client, path)
+    except errors.Error as e:
+        module.fail_json(msg=str(e))
+
     if remote_object is None and state == 'disabled' and module.params['password'] is None:
         module.fail_json(msg='Cannot disable a non existent user')
 

--- a/tests/unit/modules/test_user.py
+++ b/tests/unit/modules/test_user.py
@@ -160,3 +160,14 @@ class TestUser(ModuleTestCase):
 
         with pytest.raises(AnsibleFailJson):
             user.main()
+
+    def test_failure_on_initial_get(self, mocker):
+        get_mock = mocker.patch.object(utils, 'get')
+        get_mock.side_effect = errors.Error('Bad error')
+        set_module_args(
+            name='test_user',
+            password='password'
+        )
+
+        with pytest.raises(AnsibleFailJson):
+            user.main()


### PR DESCRIPTION
The user module needs to fetch any preexisting users from the backend before it can properly validate the parameter combination we received. Unfortunately, we forgot to handle any errors that stem from this communication with the backend and left the initial GET request unprotected.