### PR TITLE
Properly handle assets in a deprecated format

### DIFF
--- a/plugins/modules/asset.py
+++ b/plugins/modules/asset.py
@@ -123,6 +123,11 @@ def _build_set(builds):
 
 
 def _do_builds_differ(current, desired):
+    # Since Sensu Go 5.16, the web API returns builds: None if the asset
+    # in question is a deprecated, single-build asset.
+    if current is None:
+        return True
+
     if len(current) != len(desired):
         return True
 

--- a/tests/integration/molecule/module_asset/playbook.yml
+++ b/tests/integration/molecule/module_asset/playbook.yml
@@ -1,4 +1,20 @@
 ---
+- name: Setup sensuctl
+  hosts: all
+  gather_facts: no
+
+  tasks:
+    - name: Configure sensuctl
+      command:
+        cmd: >
+          sensuctl configure
+          --non-interactive
+          --url http://localhost:8080
+          --username admin
+          --password P@ssw0rd!
+          --namespace default
+
+
 - name: Converge
   collections:
     - sensu.sensu_go
@@ -209,3 +225,36 @@
     - assert:
         that:
           - result.objects == []
+
+    - name: Create an asset with a deprecated definition
+      shell:
+        cmd: |
+          cat <<EOF | sensuctl create
+          type: Asset
+          api_version: core/v2
+          metadata:
+            name: old_asset
+            namespace: default
+          spec:
+            url: https://example.com/sensu-cpu-check_0.0.3_linux_amd64.tar.gz
+            sha512: 0ce9d52b270b77f4cab754e55732ae002228201d0bd01a89b954a0655b88c1ee6546e2f82cfd1eec04689af90ad940cde128e8867912d9e415f4a58d7fdcdadf
+            filters:
+              - entity.system.os == 'linux'
+              - entity.system.arch == 'amd64'
+          EOF
+
+    - name: Update deprecated asset
+      asset:
+        auth:
+          url: http://localhost:8080
+        name: old_asset
+        builds:
+          - url: https://example.com/sensu-cpu-check_0.0.3_linux_amd64.tar.gz
+            sha512: 0ce9d52b270b77f4cab754e55732ae002228201d0bd01a89b954a0655b88c1ee6546e2f82cfd1eec04689af90ad940cde128e8867912d9e415f4a58d7fdcdadf
+            filters:
+              - entity.system.os == 'linux'
+              - entity.system.arch == 'amd64'
+      register: result
+
+    - assert:
+        that: result is changed


### PR DESCRIPTION
When asked about the asset information, the Sensu backend returns `builds: null` field since 5.16. This confused our comparator because we always expected the builds parameter to be a list if present.

Fixes #150 