### PR TITLE
Update return value specification for info modules

### DIFF
--- a/plugins/modules/asset_info.py
+++ b/plugins/modules/asset_info.py
@@ -55,7 +55,7 @@ EXAMPLES = """
 RETURN = """
 objects:
   description: list of Sensu assets
-  returned: always
+  returned: success
   type: list
 """
 

--- a/plugins/modules/check_info.py
+++ b/plugins/modules/check_info.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 RETURN = '''
 objects:
   description: list of Sensu checks
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/cluster_role_binding_info.py
+++ b/plugins/modules/cluster_role_binding_info.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 RETURN = '''
 cluster_role_bindings:
   description: list of Sensu cluster role bindings
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/cluster_role_info.py
+++ b/plugins/modules/cluster_role_info.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 RETURN = '''
 roles:
   description: list of Sensu cluster roles
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/datastore_info.py
+++ b/plugins/modules/datastore_info.py
@@ -49,7 +49,7 @@ EXAMPLES = """
 RETURN = """
 objects:
   description: list of external Sensu datastore providers
-  returned: always
+  returned: success
   type: list
 """
 

--- a/plugins/modules/entity_info.py
+++ b/plugins/modules/entity_info.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 RETURN = '''
 objects:
   description: list of Sensu entities
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/event.py
+++ b/plugins/modules/event.py
@@ -155,7 +155,7 @@ EXAMPLES = '''
 RETURN = '''
 object:
   description: object representing Sensu event
-  returned: always
+  returned: success
   type: dict
 '''
 

--- a/plugins/modules/event_info.py
+++ b/plugins/modules/event_info.py
@@ -64,7 +64,7 @@ EXAMPLES = '''
 RETURN = '''
 objects:
   description: list of Sensu events
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/filter_info.py
+++ b/plugins/modules/filter_info.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 RETURN = '''
 objects:
   description: list of Sensu filters
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/handler_info.py
+++ b/plugins/modules/handler_info.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 RETURN = '''
 objects:
   description: list of Sensu handlers
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/hook_info.py
+++ b/plugins/modules/hook_info.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 RETURN = '''
 objects:
   description: list of Sensu hooks
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/mutator_info.py
+++ b/plugins/modules/mutator_info.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 RETURN = '''
 objects:
   description: list of Sensu mutators
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/namespace_info.py
+++ b/plugins/modules/namespace_info.py
@@ -44,7 +44,7 @@ EXAMPLES = '''
 RETURN = '''
 objects:
   description: list of Sensu namespaces
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/role_binding_info.py
+++ b/plugins/modules/role_binding_info.py
@@ -50,7 +50,7 @@ EXAMPLES = '''
 RETURN = '''
 role_bindings:
   description: list of Sensu role bindings
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/role_info.py
+++ b/plugins/modules/role_info.py
@@ -50,7 +50,7 @@ EXAMPLES = '''
 RETURN = '''
 roles:
   description: list of Sensu roles
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/silence_info.py
+++ b/plugins/modules/silence_info.py
@@ -60,7 +60,7 @@ EXAMPLES = '''
 RETURN = '''
 objects:
   description: list of Sensu silence entries
-  returned: always
+  returned: success
   type: list
 '''
 

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -48,7 +48,7 @@ EXAMPLES = '''
 RETURN = '''
 objects:
   description: list of Sensu users
-  returned: always
+  returned: success
   type: list
 '''
 


### PR DESCRIPTION
All our info modules falsely advertised that they always contain an object field while in reality, they only contain it if the API call to the backend did not fail in one way or another.

Fixes #160 