### PR TITLE
Fake event module result

### DIFF
--- a/plugins/modules/event.py
+++ b/plugins/modules/event.py
@@ -154,7 +154,7 @@ EXAMPLES = '''
 
 RETURN = '''
 object:
-  description: object representing Sensu event
+  description: object representing Sensu event (deprecated)
   returned: success
   type: dict
 '''
@@ -221,10 +221,9 @@ def _build_api_payload(client, params):
 
 
 def send_event(client, path, payload, check_mode):
-    if check_mode:
-        return True, payload
-    utils.put(client, path, payload)
-    return True, utils.get(client, path)
+    if not check_mode:
+        utils.put(client, path, payload)
+    return True, payload
 
 
 def main():


### PR DESCRIPTION
Sensu Go backend processes events in an asynchronous fashion, which makes it almost impossible to retrieve the processed event shortly after it has been sent to the backend.

Currently, after we submit an event, we query the backend for the last event. What we get back is one of the following three options:

 1. nothing, if our event is the first event ever and the backend did not manage to process it yet;
 2. previous event, if there is at least one preexisting event on the backend and our event has not been processed yet;
 3. our actual event, if the backend processed our event fast enough.

In the real world setting, the third scenario almost never happens, which means that our event module is returning bogus results most of the time.

To rectify the situation, we now simply return back the payload we sent to the backend. This ensures that we return back relevant pieces of information instead of some random or event or even none.