### PR TITLE
Make user idempotent

### DIFF
--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -91,3 +91,15 @@ class Client:
 
     def delete(self, path):
         return self.request("DELETE", path)
+
+    def validate_auth_data(self, username, password):
+        resp = http.request(
+            "GET", "{0}/auth/test".format(self.address),
+            force_basic_auth=True, url_username=username,
+            url_password=password,
+        )
+        if resp.status not in (200, 401):
+            raise errors.SensuError(
+                "Authentication test returned status {0}".format(resp.status),
+            )
+        return resp.status == 200

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -42,7 +42,7 @@ options:
   password:
     description:
       - Password for the user.
-      - Required if I(state) is C(enabled).
+      - Required if user with a desired name does not exist yet on the backend.
     type: str
   groups:
     description:
@@ -81,27 +81,94 @@ from ansible_collections.sensu.sensu_go.plugins.module_utils import (
 )
 
 
-def sync(remote_object, state, client, path, payload, check_mode):
-    if state == 'disabled' and remote_object is not None:
-        if not check_mode:
-            utils.delete(client, path)
-        return True, utils.get(client, path)
+def update_password(client, path, username, password, check_mode):
+    # Hit the auth testing API and try to validate the credentials. If the API
+    # says they are invalid, we need to update them.
+    if client.validate_auth_data(username, password):
+        return False
 
-    if remote_object is None or utils.do_differ(remote_object, payload):
+    if not check_mode:
+        utils.put(client, path + '/password', dict(
+            username=username, password=password,
+        ))
+
+    return True
+
+
+def update_groups(client, path, old_groups, new_groups, check_mode):
+    to_delete = set(old_groups).difference(new_groups)
+    to_add = set(new_groups).difference(old_groups)
+
+    if not check_mode:
+        # Next few lines are far from atomic, which means that we can leave a
+        # user in any of the intermediate states, but this is the best we can
+        # do given the API limitations.
+        for g in to_add:
+            utils.put(client, path + '/groups/' + g, None)
+        for g in to_delete:
+            utils.delete(client, path + '/groups/' + g)
+
+    return len(to_delete) + len(to_add) > 0
+
+
+def update_state(client, path, old_disabled, new_disabled, check_mode):
+    changed = old_disabled != new_disabled
+
+    if not check_mode and changed:
+        if new_disabled:  # `state: disabled` input parameter
+            utils.delete(client, path)
+        else:  # `state: enabled` input parameter
+            utils.put(client, path + '/reinstate', None)
+
+    return changed
+
+
+def sync(remote_object, client, path, payload, check_mode):
+    # Create new user (either enabled or disabled)
+    if remote_object is None:
         if check_mode:
             return True, payload
         utils.put(client, path, payload)
         return True, utils.get(client, path)
 
-    return False, remote_object
+    # Update existing user. We do this on a field-by-field basis because the
+    # upsteam API for updating users requires a password field to be set. Of
+    # course, we do not want to force users to specify an existing password
+    # just for the sake of updating the group membership, so this is why we
+    # use field-specific API endpoints to update the user data.
+
+    changed = False
+    if 'password' in payload:
+        changed = update_password(
+            client, path, payload['username'], payload['password'],
+            check_mode,
+        ) or changed
+
+    if 'groups' in payload:
+        changed = update_groups(
+            client, path, remote_object.get('groups') or [],
+            payload['groups'], check_mode,
+        ) or changed
+
+    if 'disabled' in payload:
+        changed = update_state(
+            client, path, remote_object['disabled'], payload['disabled'],
+            check_mode,
+        ) or changed
+
+    if check_mode:
+        # Backend does not return back passwords, so we should follow the
+        # example set by the backend API.
+        return changed, dict(
+            remote_object,
+            **{k: v for k, v in payload.items() if k != 'password'}
+        )
+
+    return changed, utils.get(client, path)
 
 
 def main():
-    required_if = [
-        ('state', 'enabled', ('password', ))
-    ]
     module = AnsibleModule(
-        required_if=required_if,
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec("auth", "name"),
@@ -120,15 +187,14 @@ def main():
 
     client = arguments.get_sensu_client(module.params['auth'])
     path = utils.build_core_v2_path(None, 'users', module.params['name'])
-    state = module.params['state']
 
     try:
         remote_object = utils.get(client, path)
     except errors.Error as e:
         module.fail_json(msg=str(e))
 
-    if remote_object is None and state == 'disabled' and module.params['password'] is None:
-        module.fail_json(msg='Cannot disable a non existent user')
+    if remote_object is None and module.params['password'] is None:
+        module.fail_json(msg='Cannot create new user without a password')
 
     payload = arguments.get_spec_payload(module.params, 'password', 'groups')
     payload['username'] = module.params['name']
@@ -136,7 +202,7 @@ def main():
 
     try:
         changed, user = sync(
-            remote_object, state, client, path, payload, module.check_mode
+            remote_object, client, path, payload, module.check_mode
         )
         module.exit_json(changed=changed, object=user)
     except errors.Error as e:

--- a/tests/integration/molecule/module_user/converge.yml
+++ b/tests/integration/molecule/module_user/converge.yml
@@ -4,11 +4,12 @@
     - sensu.sensu_go
   hosts: all
   gather_facts: no
+  environment:
+    SENSU_URL: http://localhost:8080
+
   tasks:
     - name: Create user with minimal parameters
       user:
-        auth:
-          url: http://localhost:8080
         name: awesome_username
         password: hidden_password?
       register: result
@@ -18,10 +19,51 @@
           - result is changed
           - result.object.username == 'awesome_username'
 
-    - name: Create a user
+    - name: Minimal parameter idempotence check
       user:
-        auth:
-          url: http://localhost:8080
+        name: awesome_username
+        password: hidden_password?
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Disable enabled user
+      user:
+        name: awesome_username
+        state: disabled
+      register: result
+
+    - assert:
+        that:
+          - result.object.disabled == True
+
+    - name: Add disabled user to some groups
+      user:
+        name: awesome_username
+        groups: [ a, b, c ]
+        state: disabled
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.groups | sort == ['a', 'b', 'c']
+
+    - name: Change password on disabled user
+      user:
+        name: awesome_username
+        password: new_pass
+        state: disabled
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Create a disabled user
+      user:
         name: test_username
         password: hidden_password?
         state: disabled
@@ -37,10 +79,28 @@
           - result.object.disabled == True
           - result.object.groups == ['dev', 'prod']
 
+    - name: Try to disable an already disabled user
+      user:
+        name: test_username
+        state: disabled
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Enable a disabled user
+      user:
+        name: test_username
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.object.disabled == False
+
     - name: Modify a user
       user:
-        auth:
-          url: http://localhost:8080
         name: test_username
         password: hidden_password!
         groups:
@@ -54,9 +114,10 @@
 
     - name: Fetch all users
       user_info:
-        auth:
-          url: http://localhost:8080
       register: result
+
+    - debug:
+        var: result
 
     - assert:
         that:
@@ -64,8 +125,6 @@
 
     - name: Fetch specific user
       user_info:
-        auth:
-          url: http://localhost:8080
         name: test_username
       register: result
 
@@ -73,48 +132,10 @@
         that:
           - result.objects | length == 1
           - result.objects.0.username == 'test_username'
+          - result.objects.0.disabled == False
 
-    - name: Disable user
+    - name: Try to create a user with no password
       user:
-        auth:
-          url: http://localhost:8080
-        name: test_username
-        state: disabled
-      register: result
-
-    - assert:
-        that:
-          - result.object.username == 'test_username'
-          - result.object.disabled == True
-
-    - name: Disable already disabled user
-      user:
-        auth:
-          url: http://localhost:8080
-        name: test_username
-        state: disabled
-      register: result
-
-    - assert:
-        that:
-          - result is changed
-
-    - name: Fetch test_username
-      user_info:
-        auth:
-          url: http://localhost:8080
-        name: test_username
-      register: result
-
-    - assert:
-        that:
-          - result.objects.0.username == 'test_username'
-          - result.objects.0.disabled == True
-
-    - name: Try to disable non-existent user
-      user:
-        auth:
-          url: http://localhost:8080
         name: missing_user
         state: disabled
       ignore_errors: true
@@ -126,8 +147,6 @@
 
     - name: Try to fetch non-existing user
       user_info:
-        auth:
-          url: http://localhost:8080
         name: bad-bad-user
       register: result
 


### PR DESCRIPTION
Changes in this PR make sure the user module is idempotent and that module's parameters can be set independently from one another.

Fixes #183 