### PR TITLE
Documentation updates

### DIFF
--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -80,7 +80,10 @@ Parameters
 {%     set typ = spec.type | default("any") %}
 {%     set sample = spec.sample %}
 {{ "  " * level }}{{ name }} ({{ spec.returned }}), {{ typ }}, {{ sample }})
-  {{ "  " * level }}{{ spec.description | rst_ify }}
+{%     for para in spec.description %}
+  {{ "  " * level }}{{ para | rst_ify }}
+
+{%     endfor %}
 
 {%     if spec.contains %}
 {{ result_desc(spec.contains, level + 1) }}

--- a/plugins/modules/asset.py
+++ b/plugins/modules/asset.py
@@ -45,6 +45,7 @@ options:
         provide the named asset.
       - Required if I(state) is C(present).
     type: list
+    elements: dict
     suboptions:
       url:
         description:
@@ -61,6 +62,7 @@ options:
           - A set of Sensu query expressions used to determine if the asset
             should be installed.
         type: list
+        elements: str
       headers:
         description:
           - Additional headers to send when retrieving the asset, e.g. for
@@ -172,6 +174,7 @@ def main():
                     ),
                     filters=dict(
                         type="list",
+                        elements="str",
                     ),
                     headers=dict(
                         type="dict",

--- a/plugins/modules/asset.py
+++ b/plugins/modules/asset.py
@@ -72,7 +72,7 @@ options:
 
 EXAMPLES = """
 - name: Create a multiple-build asset
-  asset:
+  sensu.sensu_go.asset:
     name: sensu-plugins-cpu-checks
     builds:
       - url: https://assets.bonsai.sensu.io/68546e739d96fd695655b77b35b5aabfbabeb056/sensu-plugins-cpu-checks_4.0.0_centos_linux_amd64.tar.gz
@@ -89,7 +89,7 @@ EXAMPLES = """
           - entity.system.platform == 'alpine'
 
 - name: Delete an asset
-  asset:
+  sensu.sensu_go.asset:
     name: sensu-plugins-cpu-check
     state: absent
 """

--- a/plugins/modules/asset_info.py
+++ b/plugins/modules/asset_info.py
@@ -38,11 +38,11 @@ seealso:
 
 EXAMPLES = """
 - name: List all Sensu assets
-  asset_info:
+  sensu.sensu_go.asset_info:
   register: result
 
 - name: List the selected Sensu asset
-  asset_info:
+  sensu.sensu_go.asset_info:
     name: my_asset
   register: result
 

--- a/plugins/modules/bonsai_asset.py
+++ b/plugins/modules/bonsai_asset.py
@@ -56,7 +56,7 @@ seealso:
 
 EXAMPLES = """
 - name: Make sure specific version of asset is installed
-  bonsai_asset:
+  sensu.sensu_go.bonsai_asset:
     name: sensu/monitoring-plugins
     version: 2.2.0-1
 
@@ -66,7 +66,7 @@ EXAMPLES = """
     state: absent
 
 - name: Store Bonsai asset under a different name
-  bonsai_asset:
+  sensu.sensu_gobonsai_asset:
     name: sensu/monitoring-plugins
     version: 2.2.0-1
     rename: sensu-monitoring-2.2.0-1

--- a/plugins/modules/check.py
+++ b/plugins/modules/check.py
@@ -43,16 +43,17 @@ options:
       - Check command to run.
       - Required if I(state) is C(present).
     type: str
-    required: true
   subscriptions:
     description:
       - List of subscriptions which receive check requests.
       - Required if I(state) is C(present).
     type: list
+    elements: str
   handlers:
     description:
       - List of handlers which receive check results.
     type: list
+    elements: str
   interval:
     description:
       - Check request interval.
@@ -92,6 +93,7 @@ options:
     description:
       - List of runtime assets required to run the check.
     type: list
+    elements: str
   check_hooks:
     description:
       - A mapping of response codes to hooks which will be run by the agent when that code is returned.
@@ -110,6 +112,7 @@ options:
         description:
           - List of attribute checks for determining which proxy entities this check should be scheduled against.
         type: list
+        elements: str
       splay:
         description:
           - Enables or disables splaying of check request scheduling.
@@ -132,6 +135,7 @@ options:
     description:
       - List of handlers which receive check results. I'm not sure why this exists.
     type: list
+    elements: str
   round_robin:
     description:
       -  An array of environment variables to use with command execution.
@@ -264,10 +268,10 @@ def main():
             ),
             command=dict(),
             subscriptions=dict(
-                type='list'
+                type='list', elements='str',
             ),
             handlers=dict(
-                type='list'
+                type='list', elements='str',
             ),
             interval=dict(
                 type='int'
@@ -295,7 +299,7 @@ def main():
                 type='int'
             ),
             runtime_assets=dict(
-                type='list'
+                type='list', elements='str',
             ),
             check_hooks=dict(
                 type='dict'
@@ -305,7 +309,7 @@ def main():
                 type='dict',
                 options=dict(
                     entity_attributes=dict(
-                        type='list'
+                        type='list', elements='str',
                     ),
                     splay=dict(
                         type='bool'
@@ -319,7 +323,7 @@ def main():
                 choices=['nagios_perfdata', 'graphite_plaintext', 'influxdb_line', 'opentsdb_line']
             ),
             output_metric_handlers=dict(
-                type='list'
+                type='list', elements='str',
             ),
             round_robin=dict(
                 type='bool'

--- a/plugins/modules/check.py
+++ b/plugins/modules/check.py
@@ -148,7 +148,7 @@ options:
 
 EXAMPLES = '''
 - name: Check executing command every 30 seconds
-  check:
+  sensu.sensu_go.check:
     name: check
     command: check-cpu.sh -w 75 -c 90
     subscriptions:
@@ -157,7 +157,7 @@ EXAMPLES = '''
     publish: yes
 
 - name: Check executing command with cron scheduler
-  check:
+  sensu.sensu_go.check:
     name: check
     command: check-cpu.sh -w 75 -c 90
     subscriptions:
@@ -168,7 +168,7 @@ EXAMPLES = '''
     publish: yes
 
 - name: Ad-hoc scheduling
-  check:
+  sensu.sensu_go.check:
     name: check
     command: check-cpu.sh -w 75 -c 90
     subscriptions:
@@ -179,7 +179,7 @@ EXAMPLES = '''
     publish: no
 
 - name: Report events under proxy entity name instead of agent entity
-  check:
+  sensu.sensu_go.check:
     name: check
     command: http_check.sh https://sensu.io
     subscriptions:
@@ -192,7 +192,7 @@ EXAMPLES = '''
     publish: yes
 
 - name: Remove check
-  check:
+  sensu.sensu_go.check:
     name: my-check
     state: absent
 '''

--- a/plugins/modules/check_info.py
+++ b/plugins/modules/check_info.py
@@ -37,11 +37,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List all Sensu checks
-  check_info:
+  sensu.sensu_go.check_info:
   register: result
 
 - name: Obtain a specific check
-  check_info:
+  sensu.sensu_go.check_info:
     name: my-check
   register: result
 '''

--- a/plugins/modules/cluster_role.py
+++ b/plugins/modules/cluster_role.py
@@ -42,17 +42,20 @@ options:
       - Rules that the cluster role applies.
       - Must be non-empty if I(state) is C(present).
     type: list
+    elements: dict
     suboptions:
       verbs:
         description:
           - Permissions to be applied by the rule.
         type: list
+        elements: str
         required: yes
         choices: [get, list, create, update, delete]
       resources:
         description:
           - Types of resources the rule has permission to access.
         type: list
+        elements: str
         required: yes
       resource_names:
         description:
@@ -60,6 +63,7 @@ options:
           - Note that for the C(create) verb, this argument will not be
             taken into account when enforcing RBAC, even if it is provided.
         type: list
+        elements: str
 '''
 
 EXAMPLES = '''
@@ -105,14 +109,17 @@ def main():
                     verbs=dict(
                         required=True,
                         type="list",
+                        elements="str",
                         choices=["get", "list", "create", "update", "delete"],
                     ),
                     resources=dict(
                         required=True,
                         type="list",
+                        elements="str",
                     ),
                     resource_names=dict(
                         type="list",
+                        elements="str",
                     ),
                 )
             )

--- a/plugins/modules/cluster_role.py
+++ b/plugins/modules/cluster_role.py
@@ -68,7 +68,7 @@ options:
 
 EXAMPLES = '''
 - name: Create a cluster role
-  cluster_role:
+  sensu.sensu_go.cluster_role:
     name: readonly
     rules:
       - verbs:
@@ -79,7 +79,7 @@ EXAMPLES = '''
           - entities
 
 - name: Delete a cluster role
-  cluster_role:
+  sensu.sensu_go.cluster_role:
     name: readonly
     state: absent
 '''

--- a/plugins/modules/cluster_role_binding.py
+++ b/plugins/modules/cluster_role_binding.py
@@ -59,7 +59,7 @@ seealso:
 
 EXAMPLES = '''
 - name: Create a cluster role binding
-  cluster_role_binding:
+  sensu.sensu_go.cluster_role_binding:
     name: all-cluster-admins
     cluster_role: cluster-admin
     groups:
@@ -68,7 +68,7 @@ EXAMPLES = '''
       - alice
 
 - name: Delete a cluster role binding
-  cluster_role_binding:
+  sensu.sensu_go.cluster_role_binding:
     name: all-cluster-admins
     state: absent
 '''

--- a/plugins/modules/cluster_role_binding.py
+++ b/plugins/modules/cluster_role_binding.py
@@ -43,12 +43,14 @@ options:
       - Note that at least one of I(users) and I(groups) must be
         specified when creating a cluster role binding.
     type: list
+    elements: str
   groups:
     description:
       - List of groups to bind to the cluster role.
       - Note that at least one of I(users) and I(groups) must be
         specified when creating a cluster role binding.
     type: list
+    elements: str
 seealso:
   - module: cluster_role_binding_info
   - module: cluster_role
@@ -103,10 +105,10 @@ def main():
             arguments.get_spec("auth", "name", "state"),
             cluster_role=dict(),
             users=dict(
-                type="list",
+                type="list", elements="str",
             ),
             groups=dict(
-                type="list",
+                type="list", elements="str",
             ),
         )
     )

--- a/plugins/modules/cluster_role_binding_info.py
+++ b/plugins/modules/cluster_role_binding_info.py
@@ -37,11 +37,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List all Sensu cluster role bindings
-  cluster_role_binding_info:
+  sensu.sensu_go.cluster_role_binding_info:
   register: result
 
 - name: Retrieve a specific Sensu cluster role binding
-  cluster_role_binding_info:
+  sensu.sensu_go.cluster_role_binding_info:
     name: my-binding
   register: result
 '''

--- a/plugins/modules/cluster_role_info.py
+++ b/plugins/modules/cluster_role_info.py
@@ -37,11 +37,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List all Sensu cluster roles
-  role_info:
+  sensu.sensu_go.cluster_role_info:
   register: result
 
 - name: Retrieve Sensu cluster role by name
-  role_info:
+  sensu.sensu_go.cluster_role_info:
     name: my-custer-role
   register: result
 '''

--- a/plugins/modules/datastore.py
+++ b/plugins/modules/datastore.py
@@ -49,12 +49,12 @@ notes:
 
 EXAMPLES = '''
 - name: Add external datastore
-  datastore:
+  sensu.sensu_go.datastore:
     name: my-postgres
     dsn: postgresql://user:secret@host:port/dbname
 
 - name: Remove external datastore
-  datastore:
+  sensu.sensu_go.datastore:
     name: my-postgres
     state: absent
 '''

--- a/plugins/modules/datastore_info.py
+++ b/plugins/modules/datastore_info.py
@@ -33,11 +33,11 @@ seealso:
 
 EXAMPLES = """
 - name: List all external Sensu datastores
-  datastore_info:
+  sensu.sensu_go.datastore_info:
   register: result
 
 - name: Retrieve the selected external Sensu datastore
-  datastore_info:
+  sensu.sensu_go.datastore_info:
     name: my-datastore
   register: result
 

--- a/plugins/modules/entity.py
+++ b/plugins/modules/entity.py
@@ -80,7 +80,7 @@ options:
 
 EXAMPLES = '''
 - name: Create an entity
-  entity:
+  sensu.sensu_go.entity:
     auth:
       url: http://localhost:8080
     name: entity
@@ -112,7 +112,7 @@ EXAMPLES = '''
     user: agent
 
 - name: Delete an entity
-  entity:
+  sensu.sensu_go.entity:
     name: entity
     state: absent
 '''

--- a/plugins/modules/entity.py
+++ b/plugins/modules/entity.py
@@ -47,6 +47,7 @@ options:
     description:
       - List of subscriptions for the entity.
     type: list
+    elements: str
   system:
     description:
       - System information about the entity, such as operating system and platform. See
@@ -69,6 +70,7 @@ options:
       - List of items to redact from log messages. If a value is provided,
         it overwrites the default list of items to be redacted.
     type: list
+    elements: str
   user:
     description:
       - Sensu RBAC username used by the entity. Agent entities require get,
@@ -150,7 +152,7 @@ def main():
             ),
             entity_class=dict(),
             subscriptions=dict(
-                type='list',
+                type='list', elements='str',
             ),
             system=dict(
                 type='dict'
@@ -163,7 +165,7 @@ def main():
             ),
             deregistration_handler=dict(),
             redact=dict(
-                type='list'
+                type='list', elements='str',
             ),
             user=dict()
         ),

--- a/plugins/modules/entity_info.py
+++ b/plugins/modules/entity_info.py
@@ -37,11 +37,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List all Sensu entities
-  entity_info:
+  sensu.sensu_go.entity_info:
   register: result
 
 - name: Retrieve a specific Sensu entity
-  entity_info:
+  sensu.sensu_go.entity_info:
     name: my-entity
   register: result
 '''

--- a/plugins/modules/event.py
+++ b/plugins/modules/event.py
@@ -117,7 +117,7 @@ options:
 
 EXAMPLES = '''
 - name: Create an event
-  event:
+  sensu.sensu_go.event:
     auth:
       url: http://localhost:8080
     entity: awesome_entity

--- a/plugins/modules/event.py
+++ b/plugins/modules/event.py
@@ -69,6 +69,7 @@ options:
         description:
           - Check status history for the last 21 check executions.
         type: list
+        elements: dict
       issued:
         description:
           - Time that the check request was issued in seconds since the Unix epoch.
@@ -245,7 +246,7 @@ def main():
                         type='int'
                     ),
                     history=dict(
-                        type='list'
+                        type='list', elements='dict',
                     ),
                     issued=dict(
                         type='int'

--- a/plugins/modules/event_info.py
+++ b/plugins/modules/event_info.py
@@ -46,16 +46,16 @@ options:
 
 EXAMPLES = '''
 - name: List Sensu events
-  event_info:
+  sensu.sensu_go.event_info:
   register: result
 
 - name: List Sensu events for api.example.com
-  event_info:
+  sensu.sensu_go.event_info:
     entity: api.example.com
   register: result
 
 - name: Filter events by check and entity
-  event_info:
+  sensu.sensu_go.event_info:
     entity: api.example.com
     check: check-cpu
   register: result

--- a/plugins/modules/filter.py
+++ b/plugins/modules/filter.py
@@ -48,11 +48,13 @@ options:
       - Filter expressions to be compared with event data.
       - Required if I(state) is C(present).
     type: list
+    elements: str
   runtime_assets:
     description:
       - Assets to be applied to the filter's execution context.
         JavaScript files in the lib directory of the asset will be evaluated.
     type: list
+    elements: str
 '''
 
 EXAMPLES = '''
@@ -123,10 +125,10 @@ def main():
             ),
             action=dict(choices=['allow', 'deny']),
             expressions=dict(
-                type='list',
+                type='list', elements='str',
             ),
             runtime_assets=dict(
-                type='list',
+                type='list', elements='str',
             ),
         ),
     )

--- a/plugins/modules/filter.py
+++ b/plugins/modules/filter.py
@@ -59,7 +59,7 @@ options:
 
 EXAMPLES = '''
 - name: Create a filter
-  filter:
+  sensu.sensu_go.filter:
     name: filter
     action: deny
     expressions:
@@ -68,14 +68,14 @@ EXAMPLES = '''
     runtime_assets: awesomeness
 
 - name: Create a production filter
-  filter:
+  sensu.sensu_go.filter:
     name: filter
     action: allow
     expressions:
       - event.entity.labels['environment'] == 'production'
 
 - name: Create a filter with JS expression
-  filter:
+  sensu.sensu_go.filter:
     name: filter
     action: deny
     expressions:
@@ -84,7 +84,7 @@ EXAMPLES = '''
       - underscore
 
 - name: Handling repeated events
-  filter:
+  sensu.sensu_go.filter:
     name: filter_interval_60_hourly
     action: allow
     expressions:
@@ -92,7 +92,7 @@ EXAMPLES = '''
       - event.check.occurrences == 1 || event.check.occurrences % 60 == 0
 
 - name: Delete a filter
-  filter:
+  sensu.sensu_go.filter:
     name: filter_interval_60_hourly
     state: absent
 '''

--- a/plugins/modules/filter_info.py
+++ b/plugins/modules/filter_info.py
@@ -37,11 +37,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List all Sensu filters
-  filter_info:
+  sensu.sensu_go.filter_info:
   register: result
 
 - name: Retrieve a specific Sensu filter
-  filter_info:
+  sensu.sensu_go.filter_info:
     name: my-filter
   register: result
 '''

--- a/plugins/modules/handler_info.py
+++ b/plugins/modules/handler_info.py
@@ -37,11 +37,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List all Sensu handlers
-  handler_info:
+  sensu.sensu_go.handler_info:
   register: result
 
 - name: Retrieve info for a specific Sensu handler
-  handler_info:
+  sensu.sensu_go.handler_info:
       name: my-handler
   register: result
 '''

--- a/plugins/modules/handler_set.py
+++ b/plugins/modules/handler_set.py
@@ -47,7 +47,7 @@ options:
 
 EXAMPLES = '''
 - name: Create a handler set
-  handler_set:
+  sensu.sensu_go.handler_set:
     name: notify_all_the_things
     handlers:
       - slack
@@ -55,7 +55,7 @@ EXAMPLES = '''
       - udp_handler
 
 - name: Delete a handler set
-  handler_set:
+  sensu.sensu_go.handler_set:
     name: notify_all_the_things
     state: absent
 '''

--- a/plugins/modules/handler_set.py
+++ b/plugins/modules/handler_set.py
@@ -42,6 +42,7 @@ options:
       - List of Sensu event handlers (names) to use for events using the handler set.
       - Required if I(state) is C(present).
     type: list
+    elements: str
 '''
 
 EXAMPLES = '''
@@ -85,7 +86,7 @@ def main():
                 "auth", "name", "state", "labels", "annotations", "namespace",
             ),
             handlers=dict(
-                type='list'
+                type='list', elements='str',
             ),
         ),
     )

--- a/plugins/modules/hook.py
+++ b/plugins/modules/hook.py
@@ -60,7 +60,7 @@ options:
 
 EXAMPLES = '''
 - name: Rudimentary auto-remediation hook
-  hook:
+  sensu.sensu_go.hook:
     auth:
       url: http://localhost:8080
     name: restart_nginx
@@ -69,7 +69,7 @@ EXAMPLES = '''
     stdin: false
 
 - name: Capture the process tree
-  hook:
+  sensu.sensu_go.hook:
     auth:
       url: http://localhost:8080
     name: process_tree
@@ -78,7 +78,7 @@ EXAMPLES = '''
     stdin: false
 
 - name: Delete a hook
-  hook:
+  sensu.sensu_go.hook:
     name: process_tree
     state: absent
 '''

--- a/plugins/modules/hook.py
+++ b/plugins/modules/hook.py
@@ -55,6 +55,7 @@ options:
     description:
       - List of runtime assets required to run the check.
     type: list
+    elements: str
 '''
 
 EXAMPLES = '''
@@ -115,7 +116,7 @@ def main():
                 type='bool'
             ),
             runtime_assets=dict(
-                type='list',
+                type='list', elements='str',
             ),
         ),
     )

--- a/plugins/modules/hook_info.py
+++ b/plugins/modules/hook_info.py
@@ -37,11 +37,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List all Sensu hooks
-  hook_info:
+  sensu.sensu_go.hook_info:
   register: result
 
 - name: Fetch a specific Sensu hook
-  hook_info:
+  sensu.sensu_go.hook_info:
     name: awesome-hook
   register: result
 '''

--- a/plugins/modules/mutator.py
+++ b/plugins/modules/mutator.py
@@ -54,6 +54,7 @@ options:
     description:
       - List of runtime assets, required to run the mutator I(command).
     type: list
+    elements: str
 '''
 
 EXAMPLES = '''
@@ -108,7 +109,7 @@ def main():
                 type='dict'
             ),
             runtime_assets=dict(
-                type='list'
+                type='list', elements='str',
             ),
         ),
     )

--- a/plugins/modules/mutator.py
+++ b/plugins/modules/mutator.py
@@ -59,7 +59,7 @@ options:
 
 EXAMPLES = '''
 - name: Create a mutator
-  mutator:
+  sensu.sensu_go.mutator:
     name: mutator
     command: sensu-influxdb-mutator
     timeout: 30
@@ -70,7 +70,7 @@ EXAMPLES = '''
       - sensu-influxdb-mutator
 
 - name: Delete a mutator
-  mutator:
+  sensu.sensu_go.mutator:
     name: mutator
     state: absent
 '''

--- a/plugins/modules/mutator_info.py
+++ b/plugins/modules/mutator_info.py
@@ -37,11 +37,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List all Sensu mutators
-  mutator_info:
+  sensu.sensu_go.mutator_info:
   register: result
 
 - name: Retrieve a single Sensu mutator
-  mutator_info:
+  sensu.sensu_go.mutator_info:
     name: my-mutator
   register: result
 '''

--- a/plugins/modules/namespace.py
+++ b/plugins/modules/namespace.py
@@ -37,12 +37,12 @@ seealso:
 
 EXAMPLES = '''
 - name: Create a new namespace
-  namespace:
+  sensu.sensu_go.namespace:
     name: production
     state: present
 
 - name: Delete a namespace
-  namespace:
+  sensu.sensu_go.namespace:
     name: staging
     state: absent
 '''

--- a/plugins/modules/namespace_info.py
+++ b/plugins/modules/namespace_info.py
@@ -37,7 +37,7 @@ seealso:
 
 EXAMPLES = '''
 - name: List Sensu namespaces
-  namespace_info:
+  sensu.sensu_go.namespace_info:
   register: result
 '''
 

--- a/plugins/modules/pipe_handler.py
+++ b/plugins/modules/pipe_handler.py
@@ -68,7 +68,7 @@ options:
 
 EXAMPLES = '''
 - name: Setup InfluxDB handler
-  pipe_handler:
+  sensu.sensu_go.pipe_handler:
     name: influx-db
     command: sensu-influxdb-handler -d sensu
     env_vars:
@@ -79,7 +79,7 @@ EXAMPLES = '''
       - sensu-influxdb-handler
 
 - name: Delete  handler
-  pipe_handler:
+  sensu.sensu_go.pipe_handler:
     name: influx-db
     state: absent
 '''

--- a/plugins/modules/pipe_handler.py
+++ b/plugins/modules/pipe_handler.py
@@ -46,6 +46,7 @@ options:
     description:
       - List of filters to use when determining whether to pass the check result to this handler.
     type: list
+    elements: str
   mutator:
     description:
       - Mutator to call for transforming the check result before passing it to this handler.
@@ -62,6 +63,7 @@ options:
     description:
       - List of runtime assets to required to run the handler C(command)
     type: list
+    elements: str
 '''
 
 EXAMPLES = '''
@@ -109,7 +111,7 @@ def main():
             ),
             command=dict(),
             filters=dict(
-                type='list',
+                type='list', elements='str',
             ),
             mutator=dict(),
             timeout=dict(
@@ -119,7 +121,7 @@ def main():
                 type='dict'
             ),
             runtime_assets=dict(
-                type='list'
+                type='list', elements='str',
             ),
         ),
     )

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -42,17 +42,20 @@ options:
       - Rules that the role applies.
       - Must be non-empty if I(state) is C(present).
     type: list
+    elements: dict
     suboptions:
       verbs:
         description:
           - Permissions to be applied by the rule.
         type: list
+        elements: str
         required: yes
         choices: [get, list, create, update, delete]
       resources:
         description:
           - Types of resources the rule has permission to access.
         type: list
+        elements: str
         required: yes
       resource_names:
         description:
@@ -60,6 +63,7 @@ options:
           - Note that for the C(create) verb, this argument will not be
             taken into account when enforcing RBAC, even if it is provided.
         type: list
+        elements: str
 '''
 
 EXAMPLES = '''
@@ -105,14 +109,17 @@ def main():
                     verbs=dict(
                         required=True,
                         type="list",
+                        elements="str",
                         choices=["get", "list", "create", "update", "delete"],
                     ),
                     resources=dict(
                         required=True,
                         type="list",
+                        elements="str",
                     ),
                     resource_names=dict(
                         type="list",
+                        elements="str",
                     ),
                 )
             )

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -68,7 +68,7 @@ options:
 
 EXAMPLES = '''
 - name: Create a role
-  role:
+  sensu.sensu_go.role:
     name: readonly
     rules:
       - verbs:
@@ -79,7 +79,7 @@ EXAMPLES = '''
           - entities
 
 - name: Delete a role
-  role:
+  sensu.sensu_go.role:
     name: readonly
     state: absent
 '''

--- a/plugins/modules/role_binding.py
+++ b/plugins/modules/role_binding.py
@@ -68,7 +68,7 @@ options:
 
 EXAMPLES = '''
 - name: Create a role binding
-  role_binding:
+  sensu.sensu_go.role_binding:
     name: dev_and_testing
     role: testers_permissive
     groups:
@@ -79,7 +79,7 @@ EXAMPLES = '''
       - alice
 
 - name: Create a role binding for admins
-  role_binding:
+  sensu.sensu_go.role_binding:
     name: org-admins
     cluster_role: admin
     groups:
@@ -87,7 +87,7 @@ EXAMPLES = '''
       - team2-admins
 
 - name: Delete a role binding
-  role_binding:
+  sensu.sensu_go.role_binding:
     name: org-admins
     state: absent
 '''

--- a/plugins/modules/role_binding.py
+++ b/plugins/modules/role_binding.py
@@ -56,12 +56,14 @@ options:
       - Note that at least one of I(users) and I(groups) must be
         specified when creating a role binding.
     type: list
+    elements: str
   groups:
     description:
       - List of groups to bind to the role or cluster role
       - Note that at least one of I(users) and I(groups) must be
         specified when creating a role binding.
     type: list
+    elements: str
 '''
 
 EXAMPLES = '''
@@ -133,10 +135,10 @@ def main():
             role=dict(),
             cluster_role=dict(),
             users=dict(
-                type="list",
+                type="list", elements="str",
             ),
             groups=dict(
-                type="list",
+                type="list", elements="str",
             ),
         )
     )

--- a/plugins/modules/role_binding_info.py
+++ b/plugins/modules/role_binding_info.py
@@ -38,11 +38,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List all Sensu role bindings
-  role_binding_info:
+  sensu.sensu_go.role_binding_info:
   register: result
 
 - name: Retrieve a single Sensu role binding
-  role_binding_info:
+  sensu.sensu_go.role_binding_info:
       name: my-role-binding
   register: result
 '''

--- a/plugins/modules/role_info.py
+++ b/plugins/modules/role_info.py
@@ -38,11 +38,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List all Sensu roles
-  role_info:
+  sensu.sensu_go.role_info:
   register: result
 
 - name: Retrieve a specific Sensu role
-  role_info:
+  sensu.sensu_go.role_info:
     name: my-role
   register: result
 '''

--- a/plugins/modules/silence.py
+++ b/plugins/modules/silence.py
@@ -73,22 +73,22 @@ options:
 
 EXAMPLES = '''
 - name: Silence a specific check
-  silence:
+  sensu.sensu_go.silence:
     subscription: proxy
     check: check-disk
 
 - name: Silence specific check regardless of the originating entities subscription
-  silence:
+  sensu.sensu_go.silence:
     check: check-cpu
 
 - name: Silence all checks on a specific entity
-  silence:
+  sensu.sensu_go.silence:
     subscription: entity:important-entity
     expire: 120
     reason: rebooting the world
 
 - name: Delete a silencing entry
-  silence:
+  sensu.sensu_go.silence:
     subscription: entity:important-entity
     state: absent
 '''

--- a/plugins/modules/silence_info.py
+++ b/plugins/modules/silence_info.py
@@ -47,11 +47,11 @@ options:
 
 EXAMPLES = '''
 - name: List all Sensu silence entries
-  silence_info:
+  sensu.sensu_go.silence_info:
   register: result
 
 - name: Fetch a specific silence with name proxy:awesome_check
-  silence_info:
+  sensu.sensu_go.silence_info:
     subscription: proxy
     check: awesome_check
   register: result

--- a/plugins/modules/socket_handler.py
+++ b/plugins/modules/socket_handler.py
@@ -49,6 +49,7 @@ options:
     description:
       - List of filters to use when determining whether to pass the check result to this handler.
     type: list
+    elements: str
   mutator:
     description:
       - Mutator to call for transforming the check result before passing it to this handler.
@@ -117,7 +118,7 @@ def main():
             ),
             type=dict(choices=['tcp', 'udp']),
             filters=dict(
-                type='list',
+                type='list', elements='str',
             ),
             mutator=dict(),
             timeout=dict(

--- a/plugins/modules/socket_handler.py
+++ b/plugins/modules/socket_handler.py
@@ -72,21 +72,21 @@ options:
 
 EXAMPLES = '''
 - name: TCP handler
-  socket_handler:
+  sensu.sensu_go.socket_handler:
     name: tcp_handler
     type: tcp
     host: 10.0.1.99
     port: 4444
 
 - name: UDP handler
-  socket_handler:
+  sensu.sensu_go.socket_handler:
     name: udp_handler
     type: udp
     host: 10.0.1.99
     port: 4444
 
 - name: Delete a handler
-  socket_handler:
+  sensu.sensu_go.socket_handler:
     name: udp_handler
     state: absent
 '''

--- a/plugins/modules/tessen.py
+++ b/plugins/modules/tessen.py
@@ -40,7 +40,7 @@ options:
 
 EXAMPLES = '''
 - name: Disable Tessen
-  tessen:
+  sensu.sensu_go.tessen:
     state: disabled
   register: result
 '''

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -53,7 +53,7 @@ options:
 
 EXAMPLES = '''
 - name: Create a user
-  user:
+  sensu.sensu_go.user:
     auth:
       url: http://localhost:8080
     name: awesome_username
@@ -63,7 +63,7 @@ EXAMPLES = '''
       - prod
 
 - name: Deactivate a user
-  user:
+  sensu.sensu_go.user:
     name: awesome_username
     state: disabled
 '''

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -48,6 +48,7 @@ options:
     description:
       - List of groups user belongs to.
     type: list
+    elements: str
 '''
 
 EXAMPLES = '''
@@ -113,7 +114,7 @@ def main():
                 no_log=True
             ),
             groups=dict(
-                type='list',
+                type='list', elements='str',
             )
         ),
     )

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -36,11 +36,11 @@ seealso:
 
 EXAMPLES = '''
 - name: List Sensu users
-  user_info:
+  sensu.sensu_go.user_info:
   register: result
 
 - name: Retrieve a single Sensu user
-  user_info:
+  sensu.sensu_go.user_info:
     name: my-user
   register: result
 '''


### PR DESCRIPTION
There are three different commits in this PR that are loosely related, and thus, I did not split them into three separate PRs.

The first commit updates the module reference template to catch up with the documentation extractor refactoring. The second commit fixes errors that ansible-test from the devel branch found in our collection.

The last commit is the main reason why we even started working on documentation refactoring: we want to direct our users towards using the FQCNs since they are the safest and most future-proof method of using the collection content.