### PR TITLE
Sensu Go 5.20.0 updates

### DIFF
--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+for f in *.docker
+do
+  ./build.sh "$f"
+done

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+readonly filename="$1"; shift
+
+readonly base=${filename%.docker}
+readonly name=${base%-*}
+readonly version=${base##*-}
+readonly tag="xlabsi/sensu-go-tests-$name:$version"
+
+docker build --pull -f "$filename" -t "$tag" .
+docker push "$tag"

--- a/docker/centos-6.docker
+++ b/docker/centos-6.docker
@@ -1,0 +1,7 @@
+FROM centos:6
+RUN yum makecache fast \
+      && yum install -y \
+           /usr/bin/python /usr/bin/python2-config sudo \
+           yum-plugin-ovl bash iproute \
+      && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf \
+      && yum clean all

--- a/docker/centos-7.docker
+++ b/docker/centos-7.docker
@@ -1,0 +1,25 @@
+FROM centos:7
+ENV container docker
+RUN ( \
+    cd /lib/systemd/system/sysinit.target.wants/; \
+    for i in *; do \
+      [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; \
+    done \
+  ); \
+  rm -f /lib/systemd/system/multi-user.target.wants/*;\
+  rm -f /etc/systemd/system/*.wants/*;\
+  rm -f /lib/systemd/system/local-fs.target.wants/*; \
+  rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+  rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+  rm -f /lib/systemd/system/basic.target.wants/*;\
+  rm -f /lib/systemd/system/anaconda.target.wants/*; \
+  yum makecache fast; \
+  yum install -y \
+    /usr/bin/python /usr/bin/python2-config sudo \
+    yum-plugin-ovl bash iproute; \
+  sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf; \
+  yum clean all; \
+  chmod 777 /root;
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD [ "/usr/sbin/init" ]

--- a/docker/centos-8.docker
+++ b/docker/centos-8.docker
@@ -1,0 +1,6 @@
+FROM centos:8
+RUN dnf makecache \
+      && dnf install -y \
+           /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 \
+           sudo bash iproute \
+      && dnf clean all

--- a/docker/debian-10.docker
+++ b/docker/debian-10.docker
@@ -1,0 +1,5 @@
+FROM debian:10
+RUN apt-get update \
+    && apt-get install -y \
+         python sudo bash ca-certificates iproute2 python-apt aptitude \
+    && apt-get clean

--- a/docker/debian-9.docker
+++ b/docker/debian-9.docker
@@ -1,0 +1,5 @@
+FROM debian:9
+RUN apt-get update \
+    && apt-get install -y \
+         python sudo bash ca-certificates iproute2 python-apt aptitude \
+    && apt-get clean

--- a/docker/redhat-7.docker
+++ b/docker/redhat-7.docker
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi7/ubi-init:latest 
+RUN yum makecache fast \
+      && yum install -y \
+           /usr/bin/python /usr/bin/python2-config sudo \
+           yum-plugin-ovl bash iproute \
+      && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf \
+      && yum clean all

--- a/docker/sensu-5.14.2.docker
+++ b/docker/sensu-5.14.2.docker
@@ -1,0 +1,8 @@
+FROM sensu/sensu:5.14.2
+RUN apk update \
+    && apk add --no-cache python sudo bash ca-certificates
+CMD [ \
+  "sensu-backend", "start", \
+  "--state-dir", "/var/lib/sensu/sensu-backend", \
+  "--log-level", "debug" \
+]

--- a/docker/sensu-5.18.1.docker
+++ b/docker/sensu-5.18.1.docker
@@ -1,0 +1,8 @@
+FROM sensu/sensu:5.18.1
+RUN apk update \
+    && apk add --no-cache python sudo bash ca-certificates
+CMD [ \
+  "sensu-backend", "start", \
+  "--state-dir", "/var/lib/sensu/sensu-backend", \
+  "--log-level", "debug" \
+]

--- a/docker/sensu-5.19.3.docker
+++ b/docker/sensu-5.19.3.docker
@@ -1,0 +1,8 @@
+FROM sensu/sensu:5.19.3
+RUN apk update \
+    && apk add --no-cache python sudo bash ca-certificates
+CMD [ \
+  "sensu-backend", "start", \
+  "--state-dir", "/var/lib/sensu/sensu-backend", \
+  "--log-level", "debug" \
+]

--- a/docker/sensu-5.20.2.docker
+++ b/docker/sensu-5.20.2.docker
@@ -1,0 +1,8 @@
+FROM sensu/sensu:5.20.2
+RUN apk update \
+    && apk add --no-cache python sudo bash ca-certificates
+CMD [ \
+  "sensu-backend", "start", \
+  "--state-dir", "/var/lib/sensu/sensu-backend", \
+  "--log-level", "debug" \
+]

--- a/docker/sensu-5.21.0.docker
+++ b/docker/sensu-5.21.0.docker
@@ -1,0 +1,8 @@
+FROM sensu/sensu:5.21.0
+RUN apk update \
+    && apk add --no-cache python sudo bash ca-certificates
+CMD [ \
+  "sensu-backend", "start", \
+  "--state-dir", "/var/lib/sensu/sensu-backend", \
+  "--log-level", "debug" \
+]

--- a/docker/ubuntu-14.04.docker
+++ b/docker/ubuntu-14.04.docker
@@ -1,0 +1,8 @@
+FROM ubuntu:14.04
+RUN rm \
+      /etc/apt/apt.conf.d/20apt-esm-hook.conf \
+      /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list \
+    && apt-get update \
+    && apt-get install -y \
+         python sudo bash ca-certificates iproute2 python-apt aptitude \
+    && apt-get clean

--- a/docker/ubuntu-16.04.docker
+++ b/docker/ubuntu-16.04.docker
@@ -1,0 +1,5 @@
+FROM ubuntu:16.04
+RUN apt-get update \
+    && apt-get install -y \
+         python sudo bash ca-certificates iproute2 python-apt aptitude \
+    && apt-get clean

--- a/docker/ubuntu-18.04.docker
+++ b/docker/ubuntu-18.04.docker
@@ -1,0 +1,5 @@
+FROM ubuntu:18.04
+RUN apt-get update \
+    && apt-get install -y \
+         python sudo bash ca-certificates iproute2 python-apt aptitude \
+    && apt-get clean

--- a/docs/source/hacking.rst
+++ b/docs/source/hacking.rst
@@ -11,5 +11,6 @@ environment together, and then we can start hacking ;)
 
    hacking/setup
    hacking/testing
+   hacking/docker-images
    hacking/documentation
    hacking/releases

--- a/docs/source/hacking/docker-images.rst
+++ b/docs/source/hacking/docker-images.rst
@@ -1,0 +1,19 @@
+Preparing docker images for integration tests
+=============================================
+
+Our test suite relies heavily on custom docker images for testing. The main
+reason that we use custom images is test speed: having prepared docker images
+vs. building them on each test execution saves a ton of time.
+
+Adding a new image is relatively straightforward process. We can just copy one
+of the preexisting definitions from the *docker* directory and update it. All
+docker files should have a name in the format of ``<name>-<tag>.docker``.
+
+To build and publish our image, we can run the *docker/build.sh* script::
+
+   $ cd docker
+   $ ./build.sh sensu-5.21.0
+
+Note that the command will add a *sensu-go-tests-* prefix to all images. In
+the previous example, the build script will build the
+*xlabsi/sensu-go-tests-sensu:5.21.0* image.

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -111,3 +111,16 @@ def prepare_result_list(result):
     if isinstance(result, list):
         return result
     return [] if result is None else [result]
+
+
+def convert_v1_to_v2_response(response):
+    # dict(metadata=<meta>, spec=dict(a=1)) -> dict(metadata=<meta>, a=1)
+
+    if not response:
+        return response
+
+    if "metadata" not in response:
+        return response["spec"]
+
+    # Move metadata key into the spec.
+    return dict(response["spec"], metadata=response["metadata"])

--- a/plugins/modules/datastore.py
+++ b/plugins/modules/datastore.py
@@ -76,12 +76,12 @@ API_GROUP = "enterprise"
 API_VERSION = "store/v1"
 
 
-def _do_differ(remote, payload):
-    return utils.do_differ(remote["spec"], payload["spec"])
+def _get(client, path):
+    return utils.convert_v1_to_v2_response(utils.get(client, path))
 
 
 def sync(state, client, list_path, resource_path, payload, check_mode):
-    datastore = utils.get(client, resource_path)
+    datastore = _get(client, resource_path)
 
     # When we are deleting stores, we do not care if there is more than one
     # datastore present. We just make sure the currently manipulated store is
@@ -98,11 +98,11 @@ def sync(state, client, list_path, resource_path, payload, check_mode):
     # If the store exists, update it and ignore the fact that there might be
     # more than one present.
     if datastore:
-        if _do_differ(datastore, payload):
+        if utils.do_differ(datastore, payload["spec"]):
             if check_mode:
-                return True, payload
+                return True, payload["spec"]
             utils.put(client, resource_path, payload)
-            return True, utils.get(client, resource_path)
+            return True, _get(client, resource_path)
         return False, datastore
 
     # When adding a new datastore, we first make sure there is no other
@@ -112,9 +112,9 @@ def sync(state, client, list_path, resource_path, payload, check_mode):
         raise errors.Error("Some other external datastore is already active.")
 
     if check_mode:
-        return True, payload
+        return True, payload["spec"]
     utils.put(client, resource_path, payload)
-    return True, utils.get(client, resource_path)
+    return True, _get(client, resource_path)
 
 
 def main():
@@ -141,7 +141,8 @@ def main():
     payload = dict(
         type="PostgresConfig",
         api_version=API_VERSION,
-        spec=arguments.get_mutation_payload(module.params, "dsn", "pool_size"),
+        metadata=dict(name=module.params["name"]),
+        spec=arguments.get_spec_payload(module.params, "dsn", "pool_size"),
     )
 
     try:
@@ -149,10 +150,7 @@ def main():
             module.params["state"], client, list_path, resource_path, payload,
             module.check_mode,
         )
-        # We simulate the behavior of v2 API here and only return the spec.
-        module.exit_json(
-            changed=changed, object=datastore and datastore["spec"],
-        )
+        module.exit_json(changed=changed, object=datastore)
     except errors.Error as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/datastore_info.py
+++ b/plugins/modules/datastore_info.py
@@ -79,10 +79,13 @@ def main():
 
     try:
         stores = utils.prepare_result_list(utils.get(client, path))
-        # We simulate the behavior of v2 API here and only return the spec.
-        module.exit_json(changed=False, objects=[s["spec"] for s in stores])
     except errors.Error as e:
         module.fail_json(msg=str(e))
+
+    # We simulate the behavior of v2 API here and only return the spec.
+    module.exit_json(changed=False, objects=[
+        utils.convert_v1_to_v2_response(s) for s in stores
+    ])
 
 
 if __name__ == "__main__":

--- a/tests/integration/base.yml
+++ b/tests/integration/base.yml
@@ -17,23 +17,24 @@ provisioner:
   lint:
     enabled: false
 platforms:
-  - name: v5.19.1
-    image: xlabsi/sensu:5.19.1
+  # Disable 5.21.x testing for now because it has quite a few problems
+  #- name: v5.21.0
+  #  image: xlabsi/sensu-go-tests-sensu:5.21.0
+  #  pre_build_image: true
+  #  pull: true
+  #  override_command: false
+  - name: v5.20.2
+    image: xlabsi/sensu-go-tests-sensu:5.20.2
+    pre_build_image: true
+    pull: true
+    override_command: false
+  - name: v5.19.3
+    image: xlabsi/sensu-go-tests-sensu:5.19.3
     pre_build_image: true
     pull: true
     override_command: false
   - name: v5.18.1
-    image: xlabsi/sensu:5.18.1
-    pre_build_image: true
-    pull: true
-    override_command: false
-  - name: v5.17.2
-    image: xlabsi/sensu:5.17.2
-    pre_build_image: true
-    pull: true
-    override_command: false
-  - name: v5.16.1
-    image: xlabsi/sensu:5.16.1
+    image: xlabsi/sensu-go-tests-sensu:5.18.1
     pre_build_image: true
     pull: true
     override_command: false

--- a/tests/integration/molecule/misc_api_authentication/molecule.yml
+++ b/tests/integration/molecule/misc_api_authentication/molecule.yml
@@ -1,16 +1,13 @@
 platforms:
-  - name: v5.15.0
-    image: xlabsi/sensu:5.15.0
+  - name: v5.20.2
+    image: xlabsi/sensu-go-tests-sensu:5.20.2
     groups: [ has_api_key_support ]
     pre_build_image: true
     pull: true
     override_command: false
   - name: v5.14.2
-    image: xlabsi/sensu:5.14.2
+    image: xlabsi/sensu-go-tests-sensu:5.14.2
     groups: [ no_api_key_support ]
     pre_build_image: true
     pull: true
-    command: >
-      sensu-backend start
-        --state-dir /var/lib/sensu/sensu-backend/etcd1
-        --log-level debug
+    override_command: false

--- a/tests/integration/molecule/module_datastore/molecule.yml
+++ b/tests/integration/molecule/module_datastore/molecule.yml
@@ -1,6 +1,0 @@
-platforms:
-  - name: v5.15.0
-    image: xlabsi/sensu:5.15.0
-    pre_build_image: true
-    pull: true
-    override_command: false

--- a/tests/integration/molecule/role_agent_default/molecule.yml
+++ b/tests/integration/molecule/role_agent_default/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: centos
-    image: xlabsi/centos:7
+    image: xlabsi/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     groups: [ agents ]

--- a/tests/integration/molecule/role_agent_secured/molecule.yml
+++ b/tests/integration/molecule/role_agent_secured/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: centos
-    image: xlabsi/centos:7
+    image: xlabsi/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     groups: [ agents ]

--- a/tests/integration/molecule/role_backend_config/molecule.yml
+++ b/tests/integration/molecule/role_backend_config/molecule.yml
@@ -9,7 +9,7 @@ scenario:
 
 platforms:
   - name: centos
-    image: xlabsi/centos:7
+    image: xlabsi/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     override_command: false

--- a/tests/integration/molecule/role_backend_default/molecule.yml
+++ b/tests/integration/molecule/role_backend_default/molecule.yml
@@ -11,7 +11,7 @@ scenario:
 
 platforms:
   - name: centos
-    image: xlabsi/centos:7
+    image: xlabsi/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     override_command: false

--- a/tests/integration/molecule/role_backend_secured/molecule.yml
+++ b/tests/integration/molecule/role_backend_secured/molecule.yml
@@ -9,7 +9,7 @@ scenario:
 
 platforms:
   - name: centos
-    image: xlabsi/centos:7
+    image: xlabsi/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     override_command: false

--- a/tests/integration/molecule/role_install_custom_build/molecule.yml
+++ b/tests/integration/molecule/role_install_custom_build/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: ubuntu
-    image: xlabsi/ubuntu:16.04
+    image: xlabsi/sensu-go-tests-ubuntu:16.04
     pre_build_image: true
     pull: true
     capabilities:
@@ -10,7 +10,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: centos
-    image: xlabsi/centos:7
+    image: xlabsi/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     capabilities:

--- a/tests/integration/molecule/role_install_custom_version/molecule.yml
+++ b/tests/integration/molecule/role_install_custom_version/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: ubuntu
-    image: xlabsi/ubuntu:16.04
+    image: xlabsi/sensu-go-tests-ubuntu:16.04
     pre_build_image: true
     pull: true
     capabilities:
@@ -10,7 +10,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: centos
-    image: xlabsi/centos:7
+    image: xlabsi/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     capabilities:

--- a/tests/integration/molecule/role_install_default/molecule.yml
+++ b/tests/integration/molecule/role_install_default/molecule.yml
@@ -10,7 +10,7 @@ scenario:
 
 platforms:
   - name: centos-6
-    image: xlabsi/centos:6
+    image: xlabsi/sensu-go-tests-centos:6
     pre_build_image: true
     pull: true
     capabilities:
@@ -19,7 +19,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: centos-8
-    image: xlabsi/centos:8
+    image: xlabsi/sensu-go-tests-centos:8
     pre_build_image: true
     pull: true
     capabilities:
@@ -28,7 +28,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: redhat-7
-    image: xlabsi/redhat:7
+    image: xlabsi/sensu-go-tests-redhat:7
     pre_build_image: true
     pull: true
     capabilities:
@@ -37,7 +37,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: debian-9
-    image: xlabsi/debian:9
+    image: xlabsi/sensu-go-tests-debian:9
     pre_build_image: true
     pull: true
     capabilities:
@@ -46,7 +46,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: debian-10
-    image: xlabsi/debian:10
+    image: xlabsi/sensu-go-tests-debian:10
     pre_build_image: true
     pull: true
     capabilities:
@@ -55,7 +55,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: ubuntu-14.04
-    image: xlabsi/ubuntu:14.04
+    image: xlabsi/sensu-go-tests-ubuntu:14.04
     pre_build_image: true
     pull: true
     capabilities:
@@ -64,7 +64,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: ubuntu-16.04
-    image: xlabsi/ubuntu:16.04
+    image: xlabsi/sensu-go-tests-ubuntu:16.04
     pre_build_image: true
     pull: true
     capabilities:
@@ -73,7 +73,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: ubuntu-18.04
-    image: xlabsi/ubuntu:18.04
+    image: xlabsi/sensu-go-tests-ubuntu:18.04
     pre_build_image: true
     pull: true
     capabilities:

--- a/tests/unit/module_utils/test_utils.py
+++ b/tests/unit/module_utils/test_utils.py
@@ -322,3 +322,19 @@ class TestPrepareResultList:
     ])
     def test_list_construction(self, input, output):
         assert output == utils.prepare_result_list(input)
+
+
+class TestConvertV1ToV2Response:
+    def test_none_passes_through(self):
+        assert utils.convert_v1_to_v2_response(None) is None
+
+    def test_spec_only_if_metadata_is_missing(self):
+        assert utils.convert_v1_to_v2_response(dict(
+            spec=dict(a=1, b=2),
+        )) == dict(a=1, b=2)
+
+    def test_add_metadata_from_toplevel(self):
+        assert utils.convert_v1_to_v2_response(dict(
+            metadata=dict(name="sample"),
+            spec=dict(a=1, b=2),
+        )) == dict(metadata=dict(name="sample"), a=1, b=2)

--- a/tests/unit/modules/test_datastore.py
+++ b/tests/unit/modules/test_datastore.py
@@ -77,7 +77,7 @@ class TestSync(ModuleTestCase):
         )
 
         assert changed is True
-        assert {"spec": {"new": "data"}} == object
+        assert {"new": "data"} == object
         client.put.assert_called_once_with(
             "/resource", {"spec": {"my": "data"}},
         )
@@ -94,7 +94,7 @@ class TestSync(ModuleTestCase):
         )
 
         assert changed is True
-        assert {"spec": {"my": "data"}} == object
+        assert {"my": "data"} == object
         client.put.assert_not_called()
 
     def test_present_current_object_does_not_differ(self, mocker):
@@ -109,7 +109,7 @@ class TestSync(ModuleTestCase):
         )
 
         assert changed is False
-        assert {"spec": {"my": "data"}} == object
+        assert {"my": "data"} == object
         client.put.assert_not_called()
 
     def test_present_current_object_does_not_differ_check(self, mocker):
@@ -124,7 +124,7 @@ class TestSync(ModuleTestCase):
         )
 
         assert changed is False
-        assert {"spec": {"my": "data"}} == object
+        assert {"my": "data"} == object
         client.put.assert_not_called()
 
     def test_present_no_current_object_empty_backend(self, mocker):
@@ -142,7 +142,7 @@ class TestSync(ModuleTestCase):
         )
 
         assert changed is True
-        assert {"spec": {"new": "data"}} == object
+        assert {"new": "data"} == object
         client.put.assert_called_once_with(
             "/resource", {"spec": {"my": "data"}},
         )
@@ -160,7 +160,7 @@ class TestSync(ModuleTestCase):
         )
 
         assert changed is True
-        assert {"spec": {"my": "data"}} == object
+        assert {"my": "data"} == object
         client.put.assert_not_called()
 
     @pytest.mark.parametrize("check", [False, True])
@@ -201,12 +201,8 @@ class TestDatastore(ModuleTestCase):
         assert payload == dict(
             type="PostgresConfig",
             api_version="store/v1",
-            spec=dict(
-                metadata=dict(
-                    name="test_datastore",
-                ),
-                dsn="my-dsn",
-            ),
+            metadata=dict(name="test_datastore"),
+            spec=dict(dsn="my-dsn"),
         )
         assert check_mode is False
 
@@ -250,13 +246,8 @@ class TestDatastore(ModuleTestCase):
         assert payload == dict(
             type="PostgresConfig",
             api_version="store/v1",
-            spec=dict(
-                metadata=dict(
-                    name="test_datastore",
-                ),
-                dsn="my-dsn",
-                pool_size=543,
-            ),
+            metadata=dict(name="test_datastore"),
+            spec=dict(dsn="my-dsn", pool_size=543),
         )
         assert check_mode is False
 


### PR DESCRIPTION
This PR contains a mix of changes that were needed to get the collection working with recent Sensu Go versions.

Note that we still do not test the collection on Sensu Go 5.21.0 because that version has serious issues with the user API that need to be resolved before we can proceed. Comment on the upstream PR that changed the API: https://github.com/sensu/sensu-go/pull/3753#issuecomment-647031225