### PR TITLE
Remove tags from our roles

### DIFF
--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -13,7 +13,6 @@
     owner: &sensu_user sensu
     group: &sensu_group sensu
     mode: "0644"
-  tags: [configure_agent]
   when: agent_trusted_ca_file is defined
 
 - name: Configure sensu-agent (/etc/sensu/agent.yml)
@@ -24,11 +23,9 @@
     group: *sensu_group
     mode: '0600'
   notify: Restart agent
-  tags: [configure_agent]
 
 - name: Start sensu-agent
   service:
     name: sensu-agent
     state: started
     enabled: yes
-  tags: [run_agent]

--- a/roles/backend/handlers/main.yml
+++ b/roles/backend/handlers/main.yml
@@ -4,5 +4,3 @@
     name: sensu-backend
     state: restarted
   when: manage_sensu_backend_service | default(False)
-  tags:
-    - run_backend

--- a/roles/backend/tasks/configure.yml
+++ b/roles/backend/tasks/configure.yml
@@ -14,7 +14,6 @@
     - { source: "{{ etcd_peer_cert_file }}", filename: etcd-peer.crt }
     - { source: "{{ etcd_peer_key_file }}", filename: etcd-peer.key, mode: '0400' }
     - { source: "{{ etcd_peer_trusted_ca_file }}", filename: etcd-peer-ca.crt }
-  tags: [configure_backend]
   when: etcd_trusted_ca_file is defined or etcd_cert_file is defined or
         etcd_key_file is defined or etcd_peer_cert_file is defined or
         etcd_peer_key_file is defined
@@ -30,7 +29,6 @@
     - { source: "{{ api_cert_file }}", filename: api.crt }
     - { source: "{{ api_key_file }}", filename: api.key, mode: '0400' }
     - { source: "{{ api_trusted_ca_file }}", filename: api-ca.crt }
-  tags: [configure_backend]
   when: api_cert_file is defined or api_key_file is defined or
         api_trusted_ca_file is defined
 
@@ -44,7 +42,6 @@
   loop:
     - { source: "{{ dashboard_cert_file }}", filename: dashboard.crt, mode: '0644' }
     - { source: "{{ dashboard_key_file }}", filename: dashboard.key, mode: '0400' }
-  tags: [configure_backend]
   when: dashboard_cert_file is defined or dashboard_key_file is defined
 
 - name: Configure sensu-backend (/etc/sensu/backend.yml)
@@ -56,4 +53,3 @@
     mode: '0600'
   notify: Restart backend
   register: configure_result
-  tags: [configure_backend]

--- a/roles/backend/tasks/start.yml
+++ b/roles/backend/tasks/start.yml
@@ -4,7 +4,6 @@
     name: sensu-backend
     state: started
     enabled: yes
-  tags: [run_backend]
 
 - name: Check for sensu-backend init command
   command:

--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -1,11 +1,6 @@
 ---
 - name: Prepare package repositories
   include_tasks: repositories.yml
-  tags:
-    - prepare_install
-    - install
 
 - name: Install selected packages
   include_tasks: packages.yml
-  tags:
-    - install

--- a/tests/integration/molecule/role_agent_default/converge.yml
+++ b/tests/integration/molecule/role_agent_default/converge.yml
@@ -8,8 +8,6 @@
   hosts: agents
   vars:
     agent_yml: /etc/sensu/agent.yml
-  tags:
-    - configure_agent
   tasks:
     - name: Agent configuration must exist
       stat:
@@ -52,8 +50,6 @@
   hosts: agents
   vars:
     agent_yml: /etc/sensu/agent.yml
-  tags:
-    - configure_agent
   tasks:
     - name: Confirm overloaded variable sets
       lineinfile:
@@ -130,8 +126,6 @@
   hosts: agents
   vars:
     agent_yml: /etc/sensu/agent.yml
-  tags:
-    - configure_agent
   tasks:
     - name: Confirm full configuration settings
       lineinfile:

--- a/tests/integration/molecule/role_agent_secured/converge.yml
+++ b/tests/integration/molecule/role_agent_secured/converge.yml
@@ -2,8 +2,6 @@
 - name: Pre-converge secure backend config step
   hosts: backends
   gather_facts: no
-  tags:
-    - configure_agent
   tasks:
     - name: Set dummy backend PKI variables
       set_fact:
@@ -21,8 +19,6 @@
 
 - name: Verify configure_agent
   hosts: agents
-  tags:
-    - configure_agent
   tasks:
     - name: The trusted CA store file must exist
       stat:
@@ -59,8 +55,6 @@
 
 - name: Verify default configuration
   hosts: agents
-  tags:
-    - configure_agent
   tasks:
     - name: Confirm that none of secured configuration settings leak in
       lineinfile:


### PR DESCRIPTION
Using tags in roles is almost useless since the only way to control 
what gets executed is by using the --[skip-]tags Ansible parameter. We cannot store this information in a configuration file or playbook itself, which makes it rather useless.

Since all of our roles are idempotent, there is little need to skip certain tasks when executing a play. Adding a few seconds to the play runtime should not matter much in vast majority of cases.

There is also one very ugly side to our tags usage: it allows users to break their runs. For example, package installation will fail if the user instructed Ansible to skip the repository setup step.

We never documented the tags, so this change does not break the public API of the roles.