### PR TITLE
Make sure backend role returns are idempotent

### DIFF
--- a/roles/backend/tasks/start.yml
+++ b/roles/backend/tasks/start.yml
@@ -23,3 +23,4 @@
   when: init_command_test.rc == 0
   register: init_command
   failed_when: init_command.rc not in (0, 3)  # 0 - OK, 3 - already initialized
+  changed_when: init_command.rc == 0

--- a/tests/integration/molecule/role_backend_default/molecule.yml
+++ b/tests/integration/molecule/role_backend_default/molecule.yml
@@ -4,6 +4,7 @@ scenario:
     - destroy
     - create
     - converge
+    - idempotence
     - verify
     - check
     - destroy


### PR DESCRIPTION
Previously, we unconditionally reported a changed state when we tried to initialize the backend although the change happens only on the first run.

This commit updates the task output appropriately and adds an idempotency test stage to the role integration tests.