### PR TITLE
Delay API key verification

### DIFF
--- a/tests/integration/molecule/misc_api_authentication/converge.yml
+++ b/tests/integration/molecule/misc_api_authentication/converge.yml
@@ -4,6 +4,24 @@
   gather_facts: no
 
   tasks:
+    - name: Create a regular user
+      sensu.sensu_go.user:
+        name: test_user
+        password: test_pass
+
+    - name: Create a regular user role
+      sensu.sensu_go.role:
+        name: test_role
+        rules:
+          - verbs: [ list ]
+            resources: [ assets ]
+
+    - name: Allow user to list entities
+      sensu.sensu_go.role_binding:
+        name: test_binding
+        role: test_role
+        users: [ test_user ]
+
     - name: Configure sensuctl
       command:
         cmd: >
@@ -14,14 +32,20 @@
           --password P@ssw0rd!
           --namespace default
 
-    - name: Create API key
+    - name: Create API key for admin
       command:
         cmd: sensuctl api-key grant admin
-      register: api_key_result
+      register: api_key_admin_result
 
-    - name: Store API key
+    - name: Create API key for test user
+      command:
+        cmd: sensuctl api-key grant test_user
+      register: api_key_test_user_result
+
+    - name: Store API keys
       set_fact:
-        api_key: "{{ api_key_result.stdout | regex_search('[^/]+$') }}"
+        api_key_admin: "{{ api_key_admin_result.stdout | regex_search('[^/]+$') }}"
+        api_key_test_user: "{{ api_key_test_user_result.stdout | regex_search('[^/]+$') }}"
 
     - name: Change default admin password for tests
       command:
@@ -84,7 +108,7 @@
     - assert:
         that:
           - result is failed
-          - "'API key' in result.msg"
+          - "'Authentication' in result.msg"
 
     - name: Fail with bad API token even if username/password would be OK
       hook:
@@ -103,7 +127,7 @@
     - assert:
         that:
           - result is failed
-          - "'API key' in result.msg"
+          - "'Authentication' in result.msg"
 
     - name: Authenticate with a valid user/pass combination
       asset:
@@ -124,7 +148,7 @@
     - name: Authenticate with a valid API key
       asset_info:
         auth:
-          api_key: "{{ api_key }}"
+          api_key: "{{ api_key_admin }}"
           url: http://localhost:8080
       register: result
 
@@ -135,7 +159,7 @@
     - name: Authenticate with a valid API key and ignore user/password
       asset_info:
         auth:
-          api_key: "{{ api_key }}"
+          api_key: "{{ api_key_admin }}"
           user: not-a-valid-user
           password: not-a-password
           url: http://localhost:8080
@@ -144,6 +168,35 @@
     - assert:
         that:
           - result is success
+
+    - name: List assets using test user API key
+      asset_info:
+        auth:
+          api_key: "{{ api_key_test_user }}"
+
+    - name: Fail to create an asset because test_user can only list them
+      bonsai_asset:
+        auth:
+          api_key: "{{ api_key_test_user }}"
+        name: sensu/monitoring-plugins
+        version: 2.2.0-1
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
+
+    - name: Fail to list entities because test_user has no access to entities
+      entity_info:
+        auth:
+          api_key: "{{ api_key_test_user }}"
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - result is failed
 
 
 - name: Prepare old backend
@@ -222,7 +275,7 @@
     - assert:
         that:
           - result is failed
-          - "'API key' in result.msg"
+          - "'Authentication' in result.msg"
 
     - name: Fail with bad API token even if username/password would be OK
       hook:
@@ -241,7 +294,7 @@
     - assert:
         that:
           - result is failed
-          - "'API key' in result.msg"
+          - "'Authentication' in result.msg"
 
     - name: Authenticate with a valid user/pass combination
       asset:


### PR DESCRIPTION
Since Sensu Go does not offer any reliable way of checking the API key's validity, we do not validate it upfront as we do with the username and password. Instead, we catch the potential problems with the credentials in the request handler.

Fixes #191 