### PR TITLE
Cap pytest version in different environments

### DIFF
--- a/units.requirements
+++ b/units.requirements
@@ -1,5 +1,6 @@
 coverage < 5
 mock
-pytest
+pytest < 5 ; python_version <= "2.7"  # pytest 5 does not support python 2.7
+pytest < 6 ; python_version > "2.7"  # problems with relative imports
 pytest-mock
 pytest-xdist


### PR DESCRIPTION
When testing, we need to use the right version of pytest package becase:

 1. pytest >= 5 does not support python 2.7 anymore, and
 2. pytest >= 6 has some problems with relative imports in     collections.