### PR TITLE
Specify remote docker version in CI/CD configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,8 @@ jobs:
           ansible: << parameters.ansible >>
           kind: integration
           test_commands:
-            - setup_remote_docker
+            - setup_remote_docker: &docker_version
+                version: 19.03.12
             - run: make integration
 
   integration_test_galaxy:
@@ -139,7 +140,7 @@ jobs:
           ansible: << parameters.ansible >>
           kind: integration
           test_commands:
-            - setup_remote_docker
+            - setup_remote_docker: *docker_version
             - run: |
                 ansible-galaxy collection install \
                   sensu.sensu_go:$(grep version: galaxy.yml | cut -d" " -f2)


### PR DESCRIPTION
CircleCI started deprecating outdated stuff that is not supported anymore [1]. Fortunately, the only thing that affected us was the
docker version and that one was relatively easy to fix.

[1] https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572/1