### PR TITLE
Switch to using Docker images from quay.io repositories

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -7,7 +7,7 @@ readonly filename="$1"; shift
 readonly base=${filename%.docker}
 readonly name=${base%-*}
 readonly version=${base##*-}
-readonly tag="xlabsi/sensu-go-tests-$name:$version"
+readonly tag="quay.io/xlab-steampunk/sensu-go-tests-$name:$version"
 
 docker build --pull -f "$filename" -t "$tag" .
 docker push "$tag"

--- a/docs/source/hacking/docker-images.rst
+++ b/docs/source/hacking/docker-images.rst
@@ -16,4 +16,4 @@ To build and publish our image, we can run the *docker/build.sh* script::
 
 Note that the command will add a *sensu-go-tests-* prefix to all images. In
 the previous example, the build script will build the
-*xlabsi/sensu-go-tests-sensu:5.21.0* image.
+*quay.io/xlab-steampunk/sensu-go-tests-sensu:5.21.0* image.

--- a/tests/integration/base.yml
+++ b/tests/integration/base.yml
@@ -20,27 +20,27 @@ provisioner:
     enabled: false
 platforms:
   - name: v6.0.0
-    image: xlabsi/sensu-go-tests-sensu:6.0.0
+    image: quay.io/xlab-steampunk/sensu-go-tests-sensu:6.0.0
     pre_build_image: true
     pull: true
     override_command: false
   - name: v5.21.1
-    image: xlabsi/sensu-go-tests-sensu:5.21.1
+    image: quay.io/xlab-steampunk/sensu-go-tests-sensu:5.21.1
     pre_build_image: true
     pull: true
     override_command: false
   - name: v5.20.2
-    image: xlabsi/sensu-go-tests-sensu:5.20.2
+    image: quay.io/xlab-steampunk/sensu-go-tests-sensu:5.20.2
     pre_build_image: true
     pull: true
     override_command: false
   - name: v5.19.3
-    image: xlabsi/sensu-go-tests-sensu:5.19.3
+    image: quay.io/xlab-steampunk/sensu-go-tests-sensu:5.19.3
     pre_build_image: true
     pull: true
     override_command: false
   - name: v5.18.1
-    image: xlabsi/sensu-go-tests-sensu:5.18.1
+    image: quay.io/xlab-steampunk/sensu-go-tests-sensu:5.18.1
     pre_build_image: true
     pull: true
     override_command: false

--- a/tests/integration/molecule/misc_api_authentication/molecule.yml
+++ b/tests/integration/molecule/misc_api_authentication/molecule.yml
@@ -1,12 +1,12 @@
 platforms:
   - name: v5.20.2
-    image: xlabsi/sensu-go-tests-sensu:5.20.2
+    image: quay.io/xlab-steampunk/sensu-go-tests-sensu:5.20.2
     groups: [ has_api_key_support ]
     pre_build_image: true
     pull: true
     override_command: false
   - name: v5.14.2
-    image: xlabsi/sensu-go-tests-sensu:5.14.2
+    image: quay.io/xlab-steampunk/sensu-go-tests-sensu:5.14.2
     groups: [ no_api_key_support ]
     pre_build_image: true
     pull: true

--- a/tests/integration/molecule/misc_api_cert/molecule.yml
+++ b/tests/integration/molecule/misc_api_cert/molecule.yml
@@ -8,7 +8,7 @@ scenario:
 
 platforms:
   - name: backend
-    image: xlabsi/sensu-go-tests-centos:7
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     override_command: false

--- a/tests/integration/molecule/role_agent_config/molecule.yml
+++ b/tests/integration/molecule/role_agent_config/molecule.yml
@@ -9,6 +9,6 @@ scenario:
 
 platforms:
   - name: centos
-    image: xlabsi/sensu-go-tests-centos:7
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true

--- a/tests/integration/molecule/role_agent_default/molecule.yml
+++ b/tests/integration/molecule/role_agent_default/molecule.yml
@@ -10,7 +10,7 @@ scenario:
 
 platforms:
   - name: centos
-    image: xlabsi/sensu-go-tests-centos:7
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     groups: [ agents ]

--- a/tests/integration/molecule/role_agent_secured/molecule.yml
+++ b/tests/integration/molecule/role_agent_secured/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: centos
-    image: xlabsi/sensu-go-tests-centos:7
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     groups: [ agents ]

--- a/tests/integration/molecule/role_backend_config/molecule.yml
+++ b/tests/integration/molecule/role_backend_config/molecule.yml
@@ -9,6 +9,6 @@ scenario:
 
 platforms:
   - name: centos
-    image: xlabsi/sensu-go-tests-centos:7
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true

--- a/tests/integration/molecule/role_backend_default/molecule.yml
+++ b/tests/integration/molecule/role_backend_default/molecule.yml
@@ -11,7 +11,7 @@ scenario:
 
 platforms:
   - name: centos
-    image: xlabsi/sensu-go-tests-centos:7
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     override_command: false

--- a/tests/integration/molecule/role_backend_secured/molecule.yml
+++ b/tests/integration/molecule/role_backend_secured/molecule.yml
@@ -9,7 +9,7 @@ scenario:
 
 platforms:
   - name: centos
-    image: xlabsi/sensu-go-tests-centos:7
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true
     override_command: false

--- a/tests/integration/molecule/role_install_custom_build/molecule.yml
+++ b/tests/integration/molecule/role_install_custom_build/molecule.yml
@@ -1,11 +1,11 @@
 ---
 platforms:
   - name: ubuntu
-    image: xlabsi/sensu-go-tests-ubuntu:16.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:16.04
     pre_build_image: true
     pull: true
 
   - name: centos
-    image: xlabsi/sensu-go-tests-centos:7
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true

--- a/tests/integration/molecule/role_install_custom_version/molecule.yml
+++ b/tests/integration/molecule/role_install_custom_version/molecule.yml
@@ -1,11 +1,11 @@
 ---
 platforms:
   - name: ubuntu
-    image: xlabsi/sensu-go-tests-ubuntu:16.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:16.04
     pre_build_image: true
     pull: true
 
   - name: centos
-    image: xlabsi/sensu-go-tests-centos:7
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:7
     pre_build_image: true
     pull: true

--- a/tests/integration/molecule/role_install_default/molecule.yml
+++ b/tests/integration/molecule/role_install_default/molecule.yml
@@ -10,41 +10,41 @@ scenario:
 
 platforms:
   - name: centos-6
-    image: xlabsi/sensu-go-tests-centos:6
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:6
     pre_build_image: true
     pull: true
 
   - name: centos-8
-    image: xlabsi/sensu-go-tests-centos:8
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:8
     pre_build_image: true
     pull: true
 
   - name: redhat-7
-    image: xlabsi/sensu-go-tests-redhat:7
+    image: quay.io/xlab-steampunk/sensu-go-tests-redhat:7
     pre_build_image: true
     pull: true
 
   - name: debian-9
-    image: xlabsi/sensu-go-tests-debian:9
+    image: quay.io/xlab-steampunk/sensu-go-tests-debian:9
     pre_build_image: true
     pull: true
 
   - name: debian-10
-    image: xlabsi/sensu-go-tests-debian:10
+    image: quay.io/xlab-steampunk/sensu-go-tests-debian:10
     pre_build_image: true
     pull: true
 
   - name: ubuntu-14.04
-    image: xlabsi/sensu-go-tests-ubuntu:14.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:14.04
     pre_build_image: true
     pull: true
 
   - name: ubuntu-16.04
-    image: xlabsi/sensu-go-tests-ubuntu:16.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:16.04
     pre_build_image: true
     pull: true
 
   - name: ubuntu-18.04
-    image: xlabsi/sensu-go-tests-ubuntu:18.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:18.04
     pre_build_image: true
     pull: true


### PR DESCRIPTION
We recently migrated Docker images used in molecule integration tests from [DockerHub](https://hub.docker.com/u/xlabsi) to [Quay](https://quay.io/organization/xlab-steampunk) repositories. 

With this commit we ensure that Docker images are pulled from the new source. We also update the helper script for building Docker images so that images are pushed to the new location.