### PR TITLE
Transition to machine executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,39 +107,39 @@ jobs:
                 path: tests/output/junit
 
   integration_test_git:
+    parallelism: 6
     parameters:
       ansible:
         description: Ansible version to use
         type: string
-    docker:
-      - image: "circleci/python:3.8"
+    machine:
+      image: ubuntu-2004:202010-01
     working_directory: ~/ansible_collections/sensu/sensu_go
-    parallelism: 4
     steps:
       - wrapper:
           python: "3.8"
           ansible: << parameters.ansible >>
           kind: integration
+          venv_cmd: python3 -m venv
           test_commands:
-            - setup_remote_docker
             - run: make integration
 
   integration_test_galaxy:
-    parallelism: 4
+    parallelism: 6
     parameters:
       ansible:
         description: Ansible version to use
         type: string
-    docker:
-      - image: "circleci/python:3.8"
+    machine:
+      image: ubuntu-2004:202010-01
     working_directory: ~/sensu_go
     steps:
       - wrapper:
           python: "3.8"
           ansible: << parameters.ansible >>
           kind: integration
+          venv_cmd: python3 -m venv
           test_commands:
-            - setup_remote_docker
             - run: |
                 ansible-galaxy collection install \
                   sensu.sensu_go:$(grep version: galaxy.yml | cut -d" " -f2)
@@ -163,6 +163,10 @@ commands:
       test_commands:
         description: Test commands to execute
         type: steps
+      venv_cmd:
+        description: Virtual environment creation command
+        type: string
+        default: virtualenv
     steps:
       - checkout: { path: . }
       - run:
@@ -173,12 +177,13 @@ commands:
             echo "python << parameters.python >>" >> cache-id.txt
             echo "ansible << parameters.ansible >>" >> cache-id.txt
             echo "kind << parameters.kind >>" >> cache-id.txt
+            echo "venv_cmd << parameters.venv_cmd >>" >> cache-id.txt
             echo "cache busting string 0" >> cache-id.txt
       - restore_cache:
           key: '{{ checksum "cache-id.txt" }}'
       - run:
           name: Create virtual environment
-          command: virtualenv ${HOME}/venv
+          command: << parameters.venv_cmd >> ${HOME}/venv
       - run:
           name: Activate virtualenv
           command: |


### PR DESCRIPTION
CircleCI started deprecating outdated stuff that is not supported anymore [1]. Fortunately, the only thing that affected us was the
docker version and that one was relatively easy to fix. But there is a nasty twist: when we specify docker version in our remote_docker step, our test times go up by a factor of 1.5 (20 minute runs take 30 minutes with the latest docker version).

We first tried to mitigate the increased test times by bumping the parallelism of our jobs, but unfortunately, this did not fix the issue
because the docker operations started to time out. And because a flaky test is worse than no test (it is waaaaay to easy to get accustomed to seeing errors in CI/CD console and stop reacting to them), we abandoned that approach.

The approach that did work for us was to get rid of the remote docker altogether and use machine executor to run our integration tests. They are a bit slower compared to the state before the change (compared to the old and deprecated docker version), but because we can safely bump the parallelism to a higher value now, the complete test suite actually executes faster.

Now all we need to do is get automatic timing of our tests and we should be golden. But that is something for another day.

[1] https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572/1