### PR TITLE
Deprecate custom entity classes

### DIFF
--- a/plugins/modules/entity.py
+++ b/plugins/modules/entity.py
@@ -181,6 +181,19 @@ def main():
     )
     if module.params['deregistration_handler']:
         payload['deregistration'] = dict(handler=module.params['deregistration_handler'])
+
+    # As per conversation with @echlebek, the only two supported entity
+    # classes are agent and proxy. All other classes can lead to undefined
+    # behavior and should not be used.
+    eclass = payload.get('entity_class')
+    if eclass and eclass not in ('agent', 'proxy'):
+        module.deprecate(
+            'The `entity_class` parameter should be set to either `agent` or '
+            '`proxy`. All other values can result in undefined behavior of '
+            'the Sensu Go backend.',
+            version='2.0.0'
+        )
+
     try:
         changed, entity = utils.sync(
             module.params['state'], client, path, payload, module.check_mode,

--- a/tests/integration/molecule/module_entity/converge.yml
+++ b/tests/integration/molecule/module_entity/converge.yml
@@ -126,6 +126,7 @@
         that:
           - result is changed
           - result.object.entity_class == 'some_class'
+          - "'deprecations' in result"
 
     - name: Create a second entity
       entity:

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -55,3 +55,4 @@ plugins/modules/socket_handler.py import-2.6!skip
 plugins/modules/tessen.py import-2.6!skip
 plugins/modules/user.py import-2.6!skip
 plugins/modules/user_info.py import-2.6!skip
+plugins/modules/entity.py pylint:ansible-deprecated-no-collection-name # We still want to support ansible < 2.9.10


### PR DESCRIPTION
Sensu Go officially supports two entity classes: agent and proxy. Using any other class can lead to undefined behavior of the backend and should not be used in production.

In order to give Ansible users a heads-up about this issue, we added a deprecation warning into Sensu Go Ansible Collection when an unsupported entity class is passed in as a parameter.