### PR TITLE
Add support for hashed passwords in user module

### DIFF
--- a/tests/integration/molecule/module_user/converge.yml
+++ b/tests/integration/molecule/module_user/converge.yml
@@ -153,3 +153,46 @@
     - assert:
         that:
           - result.objects == []
+
+    - name: Create a user with password hash (check mode)
+      user: &hash_pass_user
+        name: hash_pass_user
+        password_hash: $5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm
+      check_mode: true
+      register: result
+    - assert:
+        that:
+          - result is changed
+          - result.object.username == "hash_pass_user"
+
+    - name: Make sure nothing changed
+      user_info:
+        name: hash_pass_user
+      register: result
+    - assert:
+        that:
+          - result.objects | length == 0
+
+    - name: Create a user with password hash
+      user: *hash_pass_user
+      register: result
+    - assert:
+        that:
+          - result is changed
+          - result.object.username == "hash_pass_user"
+
+    - name: Make sure new user appeared
+      user_info:
+        name: hash_pass_user
+      register: result
+    - assert:
+        that:
+          - result.objects | length == 1
+          - result.objects.0.username == "hash_pass_user"
+
+    - name: Create a user with password hash (failed idempotence for hash)
+      user: *hash_pass_user
+      register: result
+    - assert:
+        that:
+          - result is changed

--- a/tests/unit/modules/test_user.py
+++ b/tests/unit/modules/test_user.py
@@ -184,23 +184,23 @@ class TestSync:
         client.put.return_value = http.Response(201, '')
 
         changed, result = user.sync(
-            None, client, '/path', {'my': 'data'}, False
+            None, client, '/path', {'password': 'data'}, False
         )
 
         assert changed is True
         assert {'new': 'data'} == result
-        client.put.assert_called_once_with('/path', {'my': 'data'})
+        client.put.assert_called_once_with('/path', {'password': 'data'})
 
     def test_no_current_object_check(self, mocker):
         client = mocker.Mock()
         client.get.return_value = http.Response(200, '{"new": "data"}')
 
         changed, result = user.sync(
-            None, client, '/path', {'my': 'data'}, True
+            None, client, '/path', {'password': 'data'}, True
         )
 
         assert changed is True
-        assert {'my': 'data'} == result
+        assert {} == result
         client.put.assert_not_called()
 
     def test_password_update(self, mocker):


### PR DESCRIPTION
Sensu Go's API allows us to operate using hashed passwords in certain situations. In order to align with the upstream's capabilities, we added password_hash argument to the user module.

Do note that change detection does not work when using hashed passwords because the backend does not return back enough information for us to determine if anything changed.

Fixes #217 