### PR TITLE
Prepare user module for unversioned backends 

### DIFF
--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -12,6 +12,8 @@ from . import errors, http
 
 
 class Client:
+    BAD_VERSION = version.StrictVersion("9999.99.99")
+
     def __init__(self, address, username, password, api_key, verify, ca_path):
         self.address = address.rstrip("/")
         self.username = username
@@ -45,9 +47,14 @@ class Client:
                 raise errors.SensuError(
                     "Version API did not return backend version",
                 )
-            self._version = version.StrictVersion(
-                resp.json["sensu_backend"].split("#")[0]
-            )
+            try:
+                self._version = version.StrictVersion(
+                    resp.json["sensu_backend"].split("#")[0]
+                )
+            except ValueError:
+                # Backend has no version compiled in - we are probably running
+                # againts self-compiled version from git.
+                self._version = self.BAD_VERSION
 
         return self._version
 

--- a/tests/integration/molecule/module_user/converge.yml
+++ b/tests/integration/molecule/module_user/converge.yml
@@ -153,3 +153,46 @@
     - assert:
         that:
           - result.objects == []
+
+    - name: Create a user with password hash (check mode)
+      user: &hash_pass_user
+        name: hash_pass_user
+        password_hash: $5f$14$.brXRviMZpbaleSq9kjoUuwm67V/s4IziOLGHjEqxJbzPsreQAyNm
+      check_mode: true
+      register: result
+    - assert:
+        that:
+          - result is changed
+          - result.object.username == "hash_pass_user"
+
+    - name: Make sure nothing changed
+      user_info:
+        name: hash_pass_user
+      register: result
+    - assert:
+        that:
+          - result.objects | length == 0
+
+    - name: Create a user with password hash
+      user: *hash_pass_user
+      register: result
+    - assert:
+        that:
+          - result is changed
+          - result.object.username == "hash_pass_user"
+
+    - name: Make sure new user appeared
+      user_info:
+        name: hash_pass_user
+      register: result
+    - assert:
+        that:
+          - result.objects | length == 1
+          - result.objects.0.username == "hash_pass_user"
+
+    - name: Create a user with password hash (failed idempotence for hash)
+      user: *hash_pass_user
+      register: result
+    - assert:
+        that:
+          - result is changed

--- a/tests/unit/module_utils/test_client.py
+++ b/tests/unit/module_utils/test_client.py
@@ -114,6 +114,14 @@ class TestVersion:
         with pytest.raises(errors.SensuError, match="backend"):
             c.version
 
+    def test_invalid_version(self, mocker):
+        c = client.Client("http://example.com/", "u", "p", None, True, None)
+        mocker.patch.object(c, "get").return_value = http.Response(
+            200, '{"sensu_backend":"devel"}',
+        )
+
+        assert c.version == c.BAD_VERSION
+
 
 class TestRequest:
     def test_request_payload_token(self, mocker):

--- a/tests/unit/modules/test_user.py
+++ b/tests/unit/modules/test_user.py
@@ -184,23 +184,23 @@ class TestSync:
         client.put.return_value = http.Response(201, '')
 
         changed, result = user.sync(
-            None, client, '/path', {'my': 'data'}, False
+            None, client, '/path', {'password': 'data'}, False
         )
 
         assert changed is True
         assert {'new': 'data'} == result
-        client.put.assert_called_once_with('/path', {'my': 'data'})
+        client.put.assert_called_once_with('/path', {'password': 'data'})
 
     def test_no_current_object_check(self, mocker):
         client = mocker.Mock()
         client.get.return_value = http.Response(200, '{"new": "data"}')
 
         changed, result = user.sync(
-            None, client, '/path', {'my': 'data'}, True
+            None, client, '/path', {'password': 'data'}, True
         )
 
         assert changed is True
-        assert {'my': 'data'} == result
+        assert {} == result
         client.put.assert_not_called()
 
     def test_password_update(self, mocker):


### PR DESCRIPTION
When the Sensu Go backend is compiled with default settings, no version number is added to the source. Previously, this bad version number caused the user module to fail because the default version value (devel) is not a valid version number.

Changes in this commit handle such version numbers as something waaaay in the future. This allows us to keep all of our logic intact since we are dealing with a valid version. It just happens to be a very large one ;)

Fixes #212 