### PR TITLE
Remove unused source repositories

### DIFF
--- a/roles/install/tasks/apt/prepare.yml
+++ b/roles/install/tasks/apt/prepare.yml
@@ -40,4 +40,3 @@
     repo: deb https://{{ packagecloud_auth }}packagecloud.io/sensu/{{ channel }}/{{ os }}/ {{ dist }} main
     filename: /etc/apt/sources.list.d/sensu_{{ channel }}
     validate_certs: yes
-

--- a/roles/install/tasks/apt/prepare.yml
+++ b/roles/install/tasks/apt/prepare.yml
@@ -41,8 +41,3 @@
     filename: /etc/apt/sources.list.d/sensu_{{ channel }}
     validate_certs: yes
 
-- name: Add apt source repository
-  apt_repository:
-    repo: deb-src https://{{ packagecloud_auth }}packagecloud.io/sensu/{{ channel }}/{{ os }}/ {{ dist }} main
-    filename: /etc/apt/sources.list.d/sensu_{{ channel }}
-    validate_certs: yes

--- a/roles/install/tasks/dnf/prepare.yml
+++ b/roles/install/tasks/dnf/prepare.yml
@@ -16,16 +16,3 @@
     sslcacert: /etc/pki/tls/certs/ca-bundle.crt
     metadata_expire: '300'
 
-- name: Add yum source repository
-  yum_repository:
-    name: sensu_{{ channel }}-source
-    description: sensu_{{ channel }}-source
-    file: sensu
-    baseurl: https://{{ packagecloud_auth }}packagecloud.io/sensu/{{ channel }}/{{ os }}/{{ dist }}/SRPMS
-    gpgkey: https://{{ packagecloud_auth }}packagecloud.io/sensu/{{ channel }}/gpgkey
-    gpgcheck: no
-    repo_gpgcheck: yes
-    enabled: yes
-    sslverify: yes
-    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
-    metadata_expire: '300'

--- a/roles/install/tasks/dnf/prepare.yml
+++ b/roles/install/tasks/dnf/prepare.yml
@@ -15,4 +15,3 @@
     sslverify: yes
     sslcacert: /etc/pki/tls/certs/ca-bundle.crt
     metadata_expire: '300'
-

--- a/roles/install/tasks/yum/prepare.yml
+++ b/roles/install/tasks/yum/prepare.yml
@@ -16,16 +16,3 @@
     sslcacert: /etc/pki/tls/certs/ca-bundle.crt
     metadata_expire: '300'
 
-- name: Add yum source repository
-  yum_repository:
-    name: sensu_{{ channel }}-source
-    description: sensu_{{ channel }}-source
-    file: sensu
-    baseurl: https://{{ packagecloud_auth }}packagecloud.io/sensu/{{ channel }}/{{ os }}/{{ dist }}/SRPMS
-    gpgkey: https://{{ packagecloud_auth }}packagecloud.io/sensu/{{ channel }}/gpgkey
-    gpgcheck: no
-    repo_gpgcheck: yes
-    enabled: yes
-    sslverify: yes
-    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
-    metadata_expire: '300'

--- a/roles/install/tasks/yum/prepare.yml
+++ b/roles/install/tasks/yum/prepare.yml
@@ -15,4 +15,3 @@
     sslverify: yes
     sslcacert: /etc/pki/tls/certs/ca-bundle.crt
     metadata_expire: '300'
-


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Removes deb/rpm source repositories. We don't (and probably never will) make use of the source repositories.