### PR TITLE
Make allow_downgrade configurable for dnf/yum

### DIFF
--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -6,7 +6,6 @@ packagecloud_auth: ""
 channel: stable
 version: latest
 build: latest
-allow_downgrade: no
 components:
   - sensu-go-backend
   - sensu-go-agent

--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -6,6 +6,7 @@ packagecloud_auth: ""
 channel: stable
 version: latest
 build: latest
+allow_downgrade: no
 components:
   - sensu-go-backend
   - sensu-go-agent

--- a/roles/install/tasks/dnf/install.yml
+++ b/roles/install/tasks/dnf/install.yml
@@ -6,4 +6,5 @@
   dnf:
     name: "{{ 'yum' | sensu.sensu_go.package_name(item, version, build) }}"
     state: latest  # noqa 403
+    allow_downgrade: "{{ allow_downgrade }}"
   loop: "{{ components }}"

--- a/roles/install/tasks/dnf/install.yml
+++ b/roles/install/tasks/dnf/install.yml
@@ -6,5 +6,5 @@
   dnf:
     name: "{{ 'yum' | sensu.sensu_go.package_name(item, version, build) }}"
     state: latest  # noqa 403
-    allow_downgrade: "{{ allow_downgrade }}"
+    allow_downgrade: yes
   loop: "{{ components }}"

--- a/roles/install/tasks/yum/install.yml
+++ b/roles/install/tasks/yum/install.yml
@@ -6,4 +6,5 @@
   yum:
     name: "{{ 'yum' | sensu.sensu_go.package_name(item, version, build) }}"
     state: latest  # noqa 403
+    allow_downgrade: "{{ allow_downgrade }}"
   loop: "{{ components }}"

--- a/roles/install/tasks/yum/install.yml
+++ b/roles/install/tasks/yum/install.yml
@@ -6,5 +6,5 @@
   yum:
     name: "{{ 'yum' | sensu.sensu_go.package_name(item, version, build) }}"
     state: latest  # noqa 403
-    allow_downgrade: "{{ allow_downgrade }}"
+    allow_downgrade: yes
   loop: "{{ components }}"


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

We have a need to downgrade packages internally. This makes `allow_downgrade` a configurable option (defaults to `no`).