### PR TITLE
Make sure package downgrades work

### DIFF
--- a/roles/install/tasks/apt/install.yml
+++ b/roles/install/tasks/apt/install.yml
@@ -2,6 +2,8 @@
 - name: Install component
   apt:
     name: "{{ 'apt' | sensu.sensu_go.package_name(item, version, build) }}"
-    # Apt only supports latest state on names with no version suffix.
     state: "{{ (version == 'latest') | ternary('latest', 'present') }}"
+    # FIXME(@tadeboro): This is a temporary "fix" for
+    # https://github.com/ansible/ansible/issues/29451.
+    force: true
   loop: "{{ components }}"

--- a/roles/install/tasks/yum/install.yml
+++ b/roles/install/tasks/yum/install.yml
@@ -4,6 +4,6 @@
 - name: Install component
   yum:
     name: "{{ 'yum' | sensu.sensu_go.package_name(item, version, build) }}"
-    state: latest  # noqa package-latest
+    state: "{{ (version == 'latest') | ternary('latest', 'present') }}"
     allow_downgrade: true
   loop: "{{ components }}"

--- a/tests/integration/molecule/role_install_custom_build/converge.yml
+++ b/tests/integration/molecule/role_install_custom_build/converge.yml
@@ -28,6 +28,7 @@
     - name: Update to a specific build
       include_role:
         name: sensu.sensu_go.install
+        tasks_from: packages
       vars:
         components: [sensu-go-backend]
         channel: testing
@@ -46,26 +47,4 @@
         that:
           - ansible_facts.packages["sensu-go-backend"][0].version == "5.16.0"
           - ansible_facts.packages["sensu-go-backend"][0].release == "8320"
-      when: ansible_facts.packages["sensu-go-backend"][0].source == "rpm"
-
-    - name: Update to the latest build for a specific version
-      include_role:
-        name: sensu.sensu_go.install
-      vars:
-        components: [sensu-go-backend]
-        channel: testing
-        version: 5.16.0
-
-    - package_facts:
-        manager: auto
-
-    - assert:
-        that:
-          - ansible_facts.packages["sensu-go-backend"][0].version == "5.16.0-8363"
-      when: ansible_facts.packages["sensu-go-backend"][0].source == "apt"
-
-    - assert:
-        that:
-          - ansible_facts.packages["sensu-go-backend"][0].version == "5.16.0"
-          - ansible_facts.packages["sensu-go-backend"][0].release == "8363"
       when: ansible_facts.packages["sensu-go-backend"][0].source == "rpm"

--- a/tests/integration/molecule/role_install_downgrade/converge.yml
+++ b/tests/integration/molecule/role_install_downgrade/converge.yml
@@ -1,0 +1,39 @@
+---
+- name: Test downgrade
+  hosts: all
+
+  tasks:
+    - name: Install initial version components
+      include_role:
+        name: sensu.sensu_go.install
+      vars:
+        components:
+          - sensu-go-agent
+        version: 6.2.5
+
+    - name: Make sure components are installed
+      command:
+        cmd: sensu-agent version
+      register: result
+    - assert:
+        # quiet: true
+        that:
+          - result.stdout is search("6.2.5")
+
+    - name: Downgrade components
+      include_role:
+        name: sensu.sensu_go.install
+        tasks_from: packages
+      vars:
+        components:
+          - sensu-go-agent
+        version: 6.1.4
+
+    - name: Make sure components were downgraded
+      command:
+        cmd: sensu-agent version
+      register: result
+    - assert:
+        quiet: true
+        that:
+          - result.stdout is search("6.1.4")

--- a/tests/integration/molecule/role_install_downgrade/molecule.yml
+++ b/tests/integration/molecule/role_install_downgrade/molecule.yml
@@ -1,0 +1,19 @@
+---
+platforms:
+  # dnf test
+  - name: centos-8
+    image: quay.io/xlab-steampunk/sensu-go-tests-centos:8
+    pre_build_image: true
+    pull: true
+
+  # yum test
+  - name: redhat-7
+    image: quay.io/xlab-steampunk/sensu-go-tests-redhat:7
+    pre_build_image: true
+    pull: true
+
+  # apt test
+  - name: debian-10
+    image: quay.io/xlab-steampunk/sensu-go-tests-debian:10
+    pre_build_image: true
+    pull: true


### PR DESCRIPTION
In order to make sure package downgrades work as intended, we added an integration test that performs a downgrade process.

Once we run the test, we discovered that apt and yum are having troubles with the downgrade process. Fixing the yum issue was easy: we just had to replace the `state: latest` with the `state: present` when we had a version number specified.

Fixing the apt issue was a bit more tricky because the apt Ansible module does not have a parameter for allowing downgrades. For the time being, we resolved this by adding a `force: true` to the apt invocation. We should remove this temporary hack as soon as the upstream adds options for downgrading packages.