### PR TITLE
Remove hard dependency on ansible.windows

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -78,3 +78,17 @@ Go collection by running::
 
 .. _releases page:
    https://github.com/sensu/sensu-go-ansible/releases
+
+
+Installing the Windows Ansible Collection
+-----------------------------------------
+
+If we are using Ansible Base or Ansible Core, we need to install the
+`ansible.windows` Ansible Collection manually::
+
+   $ ansible-galaxy collection install ansible.windows
+
+Why is this manual step needed? While it is technically possible to declare
+collection dependencies, this may pose a problem for Automation Hub users.
+The Windows Ansible Collection is not yet certified, so we had to make it an
+optional dependency for the time being.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,6 +19,3 @@ repository: https://github.com/sensu/sensu-go-ansible
 issues: https://github.com/sensu/sensu-go-ansible/issues
 documentation: https://sensu.github.io/sensu-go-ansible/
 homepage: https://sensu.github.io/sensu-go-ansible/
-
-dependencies:
-  "ansible.windows": "*"  # Agent installation on Windows


### PR DESCRIPTION
Because the `ansible.windows` Ansible Collection is not certified yet, hard dependency on that collection will prevent Automation Hub users from installing the Sensu Go Ansible Collection. We also added some additional instructions on how to manually install the Windows Ansible Collection for those users.

Do note that removing the `ansible.windows` dependency from the metadata has one major drawback: execution environments will not be able to manage Windows agent installations.

Fixes #275 