### PR TITLE
Fix in seealso string in auth provider info module

### DIFF
--- a/plugins/modules/auth_provider_info.py
+++ b/plugins/modules/auth_provider_info.py
@@ -38,7 +38,9 @@ extends_documentation_fragment:
   - sensu.sensu_go.info
 
 seealso:
-  - module: sensu.sensu_go.auth_provider
+  - module: sensu.sensu_go.ad_auth_provider
+  - module: sensu.sensu_go.ldap_auth_provider
+  - module: sensu.sensu_go.oidc_auth_provider
 """
 
 EXAMPLES = """


### PR DESCRIPTION
Fix for auth provider info module in "seealso" string.
We list other auth provider modules related to this one
as they were missing.