### PR TITLE
Add support for OracleLinux

### DIFF
--- a/roles/install/vars/OracleLinux.yml
+++ b/roles/install/vars/OracleLinux.yml
@@ -1,0 +1,1 @@
+CentOS.yml


### PR DESCRIPTION
Installing Sensu Agent on the Oracle Linux Based server results in following error:

```
Could not find or access 'OracleLinux.yml'
Searched in: .../collections/ansible_collections/sensu/sensu_go/roles/install/vars/OracleLinux.yml
```

Since OracleLinux is basically another RHEL fork, symlinking vars in Install role resolved the issue for me.