### PR TITLE
Reduce Debian 10 test image size

### DIFF
--- a/docker/debian-10.docker
+++ b/docker/debian-10.docker
@@ -2,4 +2,7 @@ FROM debian:10
 RUN apt-get update \
     && apt-get install -y \
          python sudo bash ca-certificates iproute2 python-apt aptitude \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /usr/share/doc \
+    && rm -rf /usr/share/man \
     && apt-get clean


### PR DESCRIPTION
From the upstream dodumentation at
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

    In addition, when you clean up the apt cache by removing
    /var/lib/apt/lists it reduces the image size, since the apt cache
    is not stored in a layer. Since the RUN statement starts with
    apt-get update, the package cache is always refreshed prior to
    apt-get install.

Patch kindly provided by Amin. Thank you!