### PR TITLE
Mark the default backend test role as xfail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ commands:
             echo "week $(date +%V)" >> cache-id.txt
             echo "ansible << parameters.ansible >>" >> cache-id.txt
             echo "kind << parameters.kind >>" >> cache-id.txt
-            echo "cache busting string 1" >> cache-id.txt
+            echo "cache busting string 2" >> cache-id.txt
       - restore_cache:
           key: '{{ checksum "cache-id.txt" }}'
       - run:

--- a/tests/integration/molecule/role_backend_default/molecule.yml
+++ b/tests/integration/molecule/role_backend_default/molecule.yml
@@ -1,4 +1,7 @@
 ---
+markers:
+  - xfail  # This test fails because Sensu Go 6.4.0 broke backend init
+
 scenario:
   test_sequence:
     - destroy


### PR DESCRIPTION
This test is failing because Sensu Go broke change detection in their 6.4.0 version. We must remove this marker once Sensu Go 6.4.1 is out.