### PR TITLE
Update CI setup for Ansible 2.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ workflows:
                 - stable-2.9
                 - stable-2.10
                 - stable-2.11
+                - stable-2.12
 
       - unit_test:
           matrix: *matrix

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,3 @@
+---
+modules:
+  python_requires: ">= 2.7"

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,0 +1,2 @@
+tests/unit/plugins/module_utils/test_utils.py pylint:ansible-deprecated-no-collection-name # sanity misdetects this as module deprecation call
+tools/windows-versions.py replace-urlopen # Maintainer tools should not be bound by the general collection constraints


### PR DESCRIPTION
The Ansible development branch was bumped to 2.13, which means we need another ignore file. And while we were at it, we also added a test configuration file that allows us to skip testing on Python 2.6 on ansible-core >= 2.12.