### PR TITLE
Install requirements for docs, befor trying to build with them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ integration_ci:  ## Run integration tests on CircleCI
 
 .PHONY: docs
 docs:  ## Build collection documentation
+	pip install -r docs.requirements
 	$(MAKE) -C docs -f Makefile.custom docs
 
 .PHONY: clean


### PR DESCRIPTION
All other cases install requirements before running. Used same patteren for docs (docs. requirements allready existed).