### PR TITLE
Update cluster_info.py

### DIFF
--- a/plugins/modules/cluster_info.py
+++ b/plugins/modules/cluster_info.py
@@ -60,8 +60,8 @@ objects:
     - metadata:
         name: beta-cluster
       api_urls:
-        - "http:s//10.20.0.1:8080"
-        - "http:s//10.20.0.2:8080"
+        - "https://10.20.0.1:8080"
+        - "https://10.20.0.2:8080"
 """
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
There is one obvious typo inside example "http:s//" instead of "https://". This PR fixes it.