### PR TITLE
Remote bonsai asset definition download

### DIFF
--- a/plugins/modules/bonsai_asset.py
+++ b/plugins/modules/bonsai_asset.py
@@ -45,6 +45,13 @@ options:
       - The name that will be used when adding the asset to Sensu.
       - If not present, value of the I(name) parameter will be used.
     type: str
+  on_remote:
+    description:
+      - If set to C(true), module will download asset defnition on remote host.
+      - If not set or set to C(false), ansible downloads asset definition
+        on control node.
+    type: bool
+    version_added: 1.13.0
 notes:
   - I(labels) and I(annotations) values are merged with the values obtained
     from Bonsai. Values passed-in as parameters take precedence over the
@@ -90,3 +97,35 @@ object:
       - sha512: 4f926bf4328f...2c58ad9ab40c9e2edc31b288d066b195b21b
         url: http://example.com/asset.tar.gz
 """
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils import bonsai, errors
+
+
+def main():
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            name=dict(
+                type="str",
+                required=True,
+            ),
+            version=dict(
+                type="str",
+                required=True,
+            ),
+        ),
+    )
+
+    try:
+        asset = bonsai.get_asset_parameters(
+            module.params["name"], module.params["version"],
+        )
+        module.exit_json(changed=False, asset=asset)
+    except errors.Error as e:
+        module.fail_json(changed=False, msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/molecule/action_bonsai_asset/converge.yml
+++ b/tests/integration/molecule/action_bonsai_asset/converge.yml
@@ -11,6 +11,7 @@
           url: http://localhost:8080
         name: sensu/monitoring-plugins
         version: 2.2.0-1
+        on_remote: true
       register: result
 
     - assert:

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,2 +1,3 @@
+plugins/modules/bonsai_asset.py validate-modules:nonexistent-parameter-documented # This is not a real module, more helper for the asset module
 tests/unit/plugins/module_utils/test_utils.py pylint:ansible-deprecated-no-collection-name # sanity misdetects this as module deprecation call
 tools/windows-versions.py replace-urlopen # Maintainer tools should not be bound by the general collection constraints

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,2 +1,3 @@
+plugins/modules/bonsai_asset.py validate-modules:nonexistent-parameter-documented # This is not a real module, more helper for the asset module
 tests/unit/plugins/module_utils/test_utils.py pylint:ansible-deprecated-no-collection-name # sanity misdetects this as module deprecation call
 tools/windows-versions.py replace-urlopen # Maintainer tools should not be bound by the general collection constraints

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,2 +1,3 @@
+plugins/modules/bonsai_asset.py validate-modules:nonexistent-parameter-documented # This is not a real module, more helper for the asset module
 tests/unit/plugins/module_utils/test_utils.py pylint:ansible-deprecated-no-collection-name # sanity misdetects this as module deprecation call
 tools/windows-versions.py replace-urlopen # Maintainer tools should not be bound by the general collection constraints

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,2 +1,3 @@
+plugins/modules/bonsai_asset.py validate-modules:nonexistent-parameter-documented # This is not a real module, more helper for the asset module
 tests/unit/plugins/module_utils/test_utils.py pylint:ansible-deprecated-no-collection-name # sanity misdetects this as module deprecation call
 tools/windows-versions.py replace-urlopen # Maintainer tools should not be bound by the general collection constraints

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,1 +1,2 @@
+plugins/modules/bonsai_asset.py validate-modules:nonexistent-parameter-documented # This is not a real module, more helper for the asset module
 tools/windows-versions.py replace-urlopen # Maintainer tools should not be bound by the general collection constraints

--- a/tests/unit/plugins/action/test_bonsai_asset.py
+++ b/tests/unit/plugins/action/test_bonsai_asset.py
@@ -112,16 +112,11 @@ class TestValidateArguments:
 
 
 class TestBuildAssetArgs:
-    def test_no_additional_metadata(self, mocker):
-        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
-        bonsai_params.return_value = dict(
-            builds=[], labels=None, annotations=None,
+    def test_no_additional_metadata(self):
+        result = bonsai_asset.ActionModule.build_asset_args(
+            dict(name="test/asset", version="1.2.3"),
+            dict(builds=[], labels=None, annotations=None),
         )
-
-        result = bonsai_asset.ActionModule.build_asset_args(dict(
-            name="test/asset",
-            version="1.2.3",
-        ))
 
         assert result == dict(
             name="test/asset",
@@ -129,16 +124,11 @@ class TestBuildAssetArgs:
             builds=[],
         )
 
-    def test_bonsai_metadata_only(self, mocker):
-        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
-        bonsai_params.return_value = dict(
-            builds=[], labels=dict(a="b"), annotations=dict(c="d"),
+    def test_bonsai_metadata_only(self):
+        result = bonsai_asset.ActionModule.build_asset_args(
+            dict(name="test/asset", version="1.2.3"),
+            dict(builds=[], labels=dict(a="b"), annotations=dict(c="d")),
         )
-
-        result = bonsai_asset.ActionModule.build_asset_args(dict(
-            name="test/asset",
-            version="1.2.3",
-        ))
 
         assert result == dict(
             name="test/asset",
@@ -148,18 +138,16 @@ class TestBuildAssetArgs:
             labels=dict(a="b"),
         )
 
-    def test_user_metadata_only(self, mocker):
-        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
-        bonsai_params.return_value = dict(
-            builds=[1, 2, 3], labels=None, annotations=None,
+    def test_user_metadata_only(self):
+        result = bonsai_asset.ActionModule.build_asset_args(
+            dict(
+                name="test/asset",
+                version="1.2.3",
+                labels=dict(my="label"),
+                annotations=dict(my="annotation"),
+            ),
+            dict(builds=[1, 2, 3], labels=None, annotations=None),
         )
-
-        result = bonsai_asset.ActionModule.build_asset_args(dict(
-            name="test/asset",
-            version="1.2.3",
-            labels=dict(my="label"),
-            annotations=dict(my="annotation"),
-        ))
 
         assert result == dict(
             name="test/asset",
@@ -169,18 +157,16 @@ class TestBuildAssetArgs:
             labels=dict(my="label"),
         )
 
-    def test_mixed_metadata(self, mocker):
-        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
-        bonsai_params.return_value = dict(
-            builds=[], labels=dict(my="x", a="b"), annotations=dict(my="c"),
+    def test_mixed_metadata(self):
+        result = bonsai_asset.ActionModule.build_asset_args(
+            dict(
+                name="test/asset",
+                version="1.2.3",
+                labels=dict(my="label"),
+                annotations=dict(my="annotation"),
+            ),
+            dict(builds=[], labels=dict(my="x", a="b"), annotations=dict(my="c")),
         )
-
-        result = bonsai_asset.ActionModule.build_asset_args(dict(
-            name="test/asset",
-            version="1.2.3",
-            labels=dict(my="label"),
-            annotations=dict(my="annotation"),
-        ))
 
         assert result == dict(
             name="test/asset",
@@ -190,17 +176,11 @@ class TestBuildAssetArgs:
             labels=dict(my="label", a="b"),
         )
 
-    def test_rename(self, mocker):
-        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
-        bonsai_params.return_value = dict(
-            builds=[], labels=None, annotations=None,
+    def test_rename(self):
+        result = bonsai_asset.ActionModule.build_asset_args(
+            dict(name="test/asset", version="1.2.3", rename="my-asset"),
+            dict(builds=[], labels=None, annotations=None),
         )
-
-        result = bonsai_asset.ActionModule.build_asset_args(dict(
-            name="test/asset",
-            version="1.2.3",
-            rename="my-asset",
-        ))
 
         assert result == dict(
             name="my-asset",
@@ -208,63 +188,99 @@ class TestBuildAssetArgs:
             builds=[],
         )
 
-    def test_auth_passthrough(self, mocker):
-        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
-        bonsai_params.return_value = dict(
-            builds=[], labels=None, annotations=None,
-        )
-
-        result = bonsai_asset.ActionModule.build_asset_args(dict(
-            auth=dict(url="http://localhost:1234"),
-            name="test/asset",
-            version="1.2.3",
-        ))
-
-        assert result == dict(
-            auth=dict(url="http://localhost:1234"),
-            name="test/asset",
-            state="present",
-            builds=[],
-        )
-
-    def test_namespace_passthrough(self, mocker):
-        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
-        bonsai_params.return_value = dict(
-            builds=[], labels=None, annotations=None,
-        )
-
-        result = bonsai_asset.ActionModule.build_asset_args(dict(
-            namespace='default',
-            name="test/asset",
-            version="1.2.3",
-        ))
-
-        assert result == dict(
-            name="test/asset",
-            namespace='default',
-            state="present",
-            builds=[],
-        )
-
-    def test_fail_bonsai(self, mocker):
-        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
-        bonsai_params.side_effect = errors.BonsaiError("Bonsai bad")
-
-        with pytest.raises(errors.Error, match="Bonsai bad"):
-            bonsai_asset.ActionModule.build_asset_args(dict(
+    def test_auth_passthrough(self):
+        result = bonsai_asset.ActionModule.build_asset_args(
+            dict(
+                auth=dict(url="http://localhost:1234"),
                 name="test/asset",
                 version="1.2.3",
-            ))
+            ),
+            dict(builds=[], labels=None, annotations=None),
+        )
 
-        bonsai_params.assert_called_with("test/asset", "1.2.3")
+        assert result == dict(
+            auth=dict(url="http://localhost:1234"),
+            name="test/asset",
+            state="present",
+            builds=[],
+        )
+
+    def test_namespace_passthrough(self):
+        result = bonsai_asset.ActionModule.build_asset_args(
+            dict(namespace='default', name="test/asset", version="1.2.3"),
+            dict(builds=[], labels=None, annotations=None),
+        )
+
+        assert result == dict(
+            name="test/asset",
+            namespace='default',
+            state="present",
+            builds=[],
+        )
+
+
+class TestDownloadAssetDefinition:
+    def get_mock_action(self, mocker, result):
+        action = bonsai_asset.ActionModule(
+            mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), loader=None,
+            templar=None, shared_loader_obj=None,
+        )
+        action._execute_module = mocker.MagicMock(return_value=result)
+        return action
+
+    def test_download_on_control_node(self, mocker):
+        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
+        bonsai_params.return_value = dict(sample="value")
+        action = self.get_mock_action(mocker, {})
+
+        result = action.download_asset_definition(
+            on_remote=False, name="test/asset", version="1.2.3", task_vars=None,
+        )
+
+        assert result == dict(sample="value")
+        bonsai_params.assert_called_once()
+        action._execute_module.assert_not_called()
+
+    def test_fail_download_on_control_node(self, mocker):
+        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
+        bonsai_params.side_effect = errors.BonsaiError("Bonsai bad")
+        action = self.get_mock_action(mocker, {})
+
+        with pytest.raises(errors.Error, match="Bonsai bad"):
+            action.download_asset_definition(
+                on_remote=False, name="test/asset", version="1.2.3", task_vars=None,
+            )
+
+        bonsai_params.assert_called_once()
+        action._execute_module.assert_not_called()
+
+    def test_download_on_target_node(self, mocker):
+        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
+        action = self.get_mock_action(mocker, dict(asset="sample"))
+
+        result = action.download_asset_definition(
+            on_remote=True, name="test/asset", version="1.2.3", task_vars=None,
+        )
+
+        assert result == "sample"
+        bonsai_params.assert_not_called()
+        action._execute_module.assert_called_once()
+
+    def test_fail_on_target_node(self, mocker):
+        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
+        action = self.get_mock_action(mocker, dict(failed=True, msg="Bad err"))
+
+        with pytest.raises(errors.Error, match="Bad err"):
+            action.download_asset_definition(
+                on_remote=True, name="test/asset", version="1.2.3", task_vars=None,
+            )
+
+        bonsai_params.assert_not_called()
+        action._execute_module.assert_called_once()
 
 
 class TestRun:
     def test_success(self, mocker):
-        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
-        bonsai_params.return_value = dict(
-            builds=[], labels=None, annotations=None,
-        )
         task = mocker.MagicMock(Task, async_val=0, args=dict(
             name="test/asset",
             version="1.2.3",
@@ -274,16 +290,15 @@ class TestRun:
             templar=None, shared_loader_obj=None,
         )
         action._execute_module = mocker.MagicMock(return_value=dict(a=3))
+        action.download_asset_definition = mocker.MagicMock(
+            return_value=dict(builds=[], labels=None, annotations=None),
+        )
 
         result = action.run()
 
         assert result == dict(a=3)
 
     def test_fail(self, mocker):
-        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
-        bonsai_params.return_value = dict(
-            builds=[], labels=None, annotations=None,
-        )
         task = mocker.MagicMock(Task, async_val=0, args=dict(
             name="test/asset",
         ))
@@ -292,6 +307,9 @@ class TestRun:
             templar=None, shared_loader_obj=None,
         )
         action._execute_module = mocker.MagicMock(return_value=dict(a=3))
+        action.download_asset_definition = mocker.MagicMock(
+            return_value=dict(builds=[], labels=None, annotations=None),
+        )
 
         result = action.run()
 

--- a/tests/unit/plugins/modules/test_bonsai_asset.py
+++ b/tests/unit/plugins/modules/test_bonsai_asset.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.sensu.sensu_go.plugins.module_utils import bonsai, errors
+from ansible_collections.sensu.sensu_go.plugins.modules import bonsai_asset
+
+from .common.utils import (
+    AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestBonsaiAsset(ModuleTestCase):
+    def test_success(self, mocker):
+        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
+        bonsai_params.return_value = dict(sample="value")
+
+        set_module_args(name="name", version="version")
+
+        with pytest.raises(AnsibleExitJson):
+            bonsai_asset.main()
+
+    def test_bonsai_failure(self, mocker):
+        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
+        bonsai_params.side_effect = errors.BonsaiError("Bonsai bad")
+
+        set_module_args(name="name", version="version")
+
+        with pytest.raises(AnsibleFailJson):
+            bonsai_asset.main()
+
+    def test_validation_failure(self, mocker):
+        bonsai_params = mocker.patch.object(bonsai, "get_asset_parameters")
+        bonsai_params.return_value = dict(sample="value")
+
+        set_module_args(version="version")
+
+        with pytest.raises(AnsibleFailJson):
+            bonsai_asset.main()


### PR DESCRIPTION
Up until now, we retrieved asset definitions from Sensu Bonsai on the control node. The reasoning for this decision was that there is a higher probability that the control node has access to the bonsai.sensu.io.

This commit allows users to select where the asset definitions should be downloaded. By default, we still download them on the control node, but for cases where the target node is more capable, we allow users to specify that they want to run the download process on the target node.

How does it work? The bonsai_asset action plugin now checks the on_remote parameter and if the parameter is missing or is set to false, performs exactly the same thing as it did before (directly download the asset definition).

If the on_remote parameter is set to true, the bonsai_asset action plugin will execute a helper module. The only job of that module is to retrieve the data on the target node and send back the asset definition to the control node. This helper module is an implementation detail and is not exposed to the users. This is why it is OK to have a mismatch in the actual module implementation and the documentation.

Fixes #311 