### PR TITLE
Unpin ansible-lint

### DIFF
--- a/sanity.requirements
+++ b/sanity.requirements
@@ -1,5 +1,4 @@
 # ansible-lint >= 4.3.0 does not support python < 3.6 anymore
-# Temporary fix for ansible-core version string change
-ansible-lint == 5.0.3a0; python_version >= "3.6"
+ansible-lint; python_version >= "3.6"
 flake8
 yamllint


### PR DESCRIPTION
We pinned Ansible Lint a whle ago because we needed some urgent fixes
from the alpha version. Now that those fixes are part of the stable
release, we can remove the pin and start using latest stable version.