### PR TITLE
Add symlink for AlmaLinux.yml for alma linux 9 support

### DIFF
--- a/roles/install/vars/AlmaLinux.yml
+++ b/roles/install/vars/AlmaLinux.yml
@@ -1,0 +1,1 @@
+Alma.yml


### PR DESCRIPTION
It appears that in Alma Linux 9 the `ansible_distribution` variable has changed to `AlmaLinux`:

```
$ ansible -m setup localhost | grep distribution
[WARNING]: No inventory was parsed, only implicit localhost is available
        "ansible_distribution": "Rocky",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/redhat-release",
        "ansible_distribution_file_variety": "RedHat",
        "ansible_distribution_major_version": "9",
        "ansible_distribution_release": "Blue Onyx",
        "ansible_distribution_version": "9.1",
```

Which results in the following error from the install playbook:

```
TASK [sensu.sensu_go.install : Include distro-specific vars (AlmaLinux)] *******
task path: /usr/share/ansible/collections/ansible_collections/sensu/sensu_go/roles/install/tasks/dnf/prepare.yml:2
Friday 31 March 2023  01:10:31 +0000 (0:00:00.101)       0:05:20.955 ********** 
fatal: [localhost]: FAILED! => {
    "ansible_facts": {},
    "ansible_included_var_files": [],
    "changed": false,
    "message": "Could not find or access 'AlmaLinux.yml'\nSearched in:\n\t/usr/share/ansible/collections/ansible_collections/sensu/sensu_go/roles/install/vars/AlmaLinux.yml\n\t/usr/share/ansible/collections/ansible_collections/sensu/sensu_go/roles/install/AlmaLinux.yml\n\t/usr/share/ansible/collections/ansible_collections/sensu/sensu_go/roles/backend/vars/AlmaLinux.yml\n\t/usr/share/ansible/collections/ansible_collections/sensu/sensu_go/roles/backend/AlmaLinux.yml\n\t/var/lib/ansible/local/roles/wonolo.sensu_server/vars/AlmaLinux.yml\n\t/var/lib/ansible/local/roles/wonolo.sensu_server/AlmaLinux.yml\n\t/usr/share/ansible/collections/ansible_collections/sensu/sensu_go/roles/install/tasks/dnf/vars/AlmaLinux.yml\n\t/usr/share/ansible/collections/ansible_collections/sensu/sensu_go/roles/install/tasks/dnf/AlmaLinux.yml\n\t/var/lib/ansible/local/playbooks/sensu/vars/AlmaLinux.yml\n\t/var/lib/ansible/local/playbooks/sensu/AlmaLinux.yml on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"
}
```

I just added a symlink for `AlmaLinux.yml` to `Alma.yml` following the example from the `RedHat.yml` and `OracleLinux.yml` ones.
