### PR TITLE
Adding bcrypt check

### DIFF
--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -23,5 +23,9 @@ class SensuError(Error):
     """ Error that signals problems with Sensu Go web API. """
 
 
+class RequirementsError(Error):
+    """ Error that signals problems with missing requirements. """
+
+
 class BonsaiError(Error):
     """ Error that signals problems with Bonsai assets. """

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -151,7 +151,7 @@ def update_password(client, path, username, password, check_mode):
             if HAS_BCRYPT:
                 hash = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt())
             else:
-                raise errors.RequirementsError("Missing bcrypt library.")
+                raise errors.RequirementsError(missing_required_lib('bcrypt'))
             utils.put(client, path + '/reset_password', dict(
                 username=username, password_hash=hash.decode('ascii'),
             ))
@@ -287,15 +287,6 @@ def main():
 
     client = arguments.get_sensu_client(module.params['auth'])
     path = utils.build_core_v2_path(None, 'users', module.params['name'])
-
-    try:
-        if not HAS_BCRYPT and client.version >= "5.21.0":
-            module.fail_json(
-                msg=missing_required_lib('bcrypt'),
-                exception=BCRYPT_IMPORT_ERROR,
-            )
-    except errors.SensuError as e:
-        module.fail_json(msg=str(e))
 
     try:
         remote_object = utils.get(client, path)

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -147,7 +147,11 @@ def update_password(client, path, username, password, check_mode):
                 username=username, password=password,
             ))
         else:
-            hash = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt())
+            # Raise exception if BCRYPT library is not present on host.
+            if HAS_BCRYPT:
+                hash = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt())
+            else:
+                raise errors.RequirementsError("Missing bcrypt library.")
             utils.put(client, path + '/reset_password', dict(
                 username=username, password_hash=hash.decode('ascii'),
             ))

--- a/tests/unit/plugins/modules/test_user.py
+++ b/tests/unit/plugins/modules/test_user.py
@@ -79,6 +79,39 @@ class TestUpdatePassword:
         client.validate_auth_data.assert_called_once_with('user', 'pass')
         client.put.assert_not_called()
 
+    @pytest.mark.parametrize(
+        # bcrypt_present                   ... is bcrypt library present (True/False).
+        # expected_exception               ... is missing requirements exception expected.
+        # expected_result                  ... expected update_password return.
+        (
+            "bcrypt_present",
+            "expected_exception",
+            "expected_result",
+        ),
+        [
+            # bcrypt present
+            (True, False, True),
+            # bcrypt not present
+            (False, True, None),
+        ],
+    )
+    def test_missing_bcrypt_library(self, mocker, bcrypt_present, expected_exception, expected_result):
+        # Mock HAS_BCRYPT global variable
+        mocker.patch("ansible_collections.sensu.sensu_go.plugins.modules.user.HAS_BCRYPT", bcrypt_present)
+
+        # Mock client
+        client = mocker.Mock()
+        client.validate_auth_data.return_value = False
+        client.version = version.StrictVersion("5.21.1")
+        client.put.return_value = http.Response(201, '')
+
+        if expected_exception:
+            with pytest.raises(errors.RequirementsError, match="Missing bcrypt library."):
+                user.update_password(client, "", "", "", False)
+        else:
+            result = user.update_password(client, "", "", "", False)
+            assert result is expected_result
+
 
 class TestUpdatePasswordHash:
     @pytest.mark.parametrize('check', [False, True])

--- a/tests/unit/plugins/modules/test_user.py
+++ b/tests/unit/plugins/modules/test_user.py
@@ -106,7 +106,7 @@ class TestUpdatePassword:
         client.put.return_value = http.Response(201, '')
 
         if expected_exception:
-            with pytest.raises(errors.RequirementsError, match="Missing bcrypt library."):
+            with pytest.raises(errors.RequirementsError):
                 user.update_password(client, "", "", "", False)
         else:
             result = user.update_password(client, "", "", "", False)
@@ -539,14 +539,24 @@ class TestUser(ModuleTestCase):
             user.main()
 
     def test_failure_on_missing_bcrypt_5_21_0_or_newer(self, mocker):
+        # Check that there is no missing library exception during user creation
         mocker.patch.object(arguments, 'get_sensu_client').return_value = (
             mocker.MagicMock(version='5.22.3')
         )
+        sync_mock = mocker.patch.object(user, 'sync')
+        sync_mock.return_value = True, {}
+
+        mocker.patch.object(utils, 'get').return_value = None
         mocker.patch.object(user, 'HAS_BCRYPT', False)
+
         set_module_args(
             name='test_user',
             password='password'
         )
 
-        with pytest.raises(AnsibleFailJson, match='bcrypt'):
+        with pytest.raises(AnsibleExitJson):
             user.main()
+        result, _client, path, payload, check_mode = sync_mock.call_args[0]
+
+        assert result is None
+        assert payload == dict(password="password", username="test_user", disabled=False)


### PR DESCRIPTION
Check for bcrypt library and raise exception only where needed.

**Expected result**
The user is created/updated with the defined (bcrypt-ed) password hash.

- [x] Bcrypt check
- [x] Unit tests