### PR TITLE
Update modules.rst

### DIFF
--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -32,7 +32,7 @@ the Sensu Go backend:
    value stored in the *SENSU_API_KEY*.
 
 .. _API key:
-   https://docs.sensu.io/sensu-go/latest/guides/use-apikey-feature/
+   https://docs.sensu.io/sensu-go/latest/operations/control-access/use-apikeys/
 
 .. note::
 


### PR DESCRIPTION
The reference to API keys in the Sensu docs is outdated and doesn't point to the correct path. This updates the path.