### PR TITLE
Versioning compatibility for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ $(molecule_scenarios):
 
 .PHONY: integration_ci
 integration_ci:  ## Run integration tests on CircleCI
-	pip3 install -r integration.requirements -r collection.requirements -r molecule.requirements
+	pip3 install -r integration.requirements -r collection.requirements
+	ansible-galaxy install -r molecule.yml
 	mkdir -p test_results/integration
 	pytest -s \
 	  --junitxml=test_results/integration/junit.xml \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ $(molecule_scenarios):
 
 .PHONY: integration_ci
 integration_ci:  ## Run integration tests on CircleCI
-	pip3 install -r integration.requirements -r collection.requirements
+	pip3 install -r integration.requirements -r collection.requirements -r molecule.requirements
 	mkdir -p test_results/integration
 	pytest -s \
 	  --junitxml=test_results/integration/junit.xml \

--- a/docker/ubuntu-20.04.docker
+++ b/docker/ubuntu-20.04.docker
@@ -1,0 +1,5 @@
+FROM ubuntu:20.04
+RUN apt-get update \
+    && apt-get install -y \
+         python sudo bash ca-certificates iproute2 python-apt aptitude \
+    && apt-get clean

--- a/docker/ubuntu-22.04.docker
+++ b/docker/ubuntu-22.04.docker
@@ -1,0 +1,5 @@
+FROM ubuntu:22.04
+RUN apt-get update \
+    && apt-get install -y \
+         python3 sudo bash ca-certificates iproute2 python3-apt aptitude \
+    && apt-get clean

--- a/integration.requirements
+++ b/integration.requirements
@@ -1,8 +1,4 @@
 molecule ~= 5.0.1
-# Temporary fix until molecule-docker can only support Ansible >= 2.9
-#git+https://github.com/xlab-steampunk/molecule-docker.git@temp-fixes#egg=molecule-docker
 molecule-docker ~= 2.1.0
 pytest
-# Temporary fix until pytest-molecule is updated to work with ansible-core
-#git+https://github.com/xlab-steampunk/pytest-molecule.git@temp-fixes#egg=pytest-molecule
 pytest-molecule ~= 2.0.0

--- a/integration.requirements
+++ b/integration.requirements
@@ -1,6 +1,8 @@
-molecule ~= 3.2.3
+molecule ~= 5.0.1
 # Temporary fix until molecule-docker can only support Ansible >= 2.9
-git+https://github.com/xlab-steampunk/molecule-docker.git@temp-fixes#egg=molecule-docker
+#git+https://github.com/xlab-steampunk/molecule-docker.git@temp-fixes#egg=molecule-docker
+molecule-docker ~= 2.1.0
 pytest
 # Temporary fix until pytest-molecule is updated to work with ansible-core
-git+https://github.com/xlab-steampunk/pytest-molecule.git@temp-fixes#egg=pytest-molecule
+#git+https://github.com/xlab-steampunk/pytest-molecule.git@temp-fixes#egg=pytest-molecule
+pytest-molecule ~= 2.0.0

--- a/molecule.requirements
+++ b/molecule.requirements
@@ -1,1 +1,0 @@
-ansible.posix

--- a/molecule.requirements
+++ b/molecule.requirements
@@ -1,0 +1,1 @@
+ansible.posix

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,2 @@
+collections:
+  - name: ansible.posix

--- a/roles/install/tasks/apt/prepare.yml
+++ b/roles/install/tasks/apt/prepare.yml
@@ -3,6 +3,10 @@
   include_vars:
     file: '{{ ansible_distribution }}.yml'
 
+- name: Update sources.list file
+  shell: echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
+  when: ansible_distribution == 'Debian' and ansible_distribution_major_version == '9'
+
 - name: Update apt cache (ensure we have package index)
   apt:
     update_cache: true

--- a/tests/integration/molecule/role_install_custom_build/molecule.yml
+++ b/tests/integration/molecule/role_install_custom_build/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: ubuntu
-    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:16.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:20.04
     pre_build_image: true
     pull: true
 

--- a/tests/integration/molecule/role_install_custom_build/molecule.yml
+++ b/tests/integration/molecule/role_install_custom_build/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: ubuntu
-    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:20.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:22.04
     pre_build_image: true
     pull: true
 

--- a/tests/integration/molecule/role_install_custom_build/molecule.yml
+++ b/tests/integration/molecule/role_install_custom_build/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: ubuntu
-    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:22.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:18.04
     pre_build_image: true
     pull: true
 

--- a/tests/integration/molecule/role_install_custom_version/molecule.yml
+++ b/tests/integration/molecule/role_install_custom_version/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: ubuntu
-    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:16.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:20.04
     pre_build_image: true
     pull: true
 

--- a/tests/integration/molecule/role_install_custom_version/molecule.yml
+++ b/tests/integration/molecule/role_install_custom_version/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: ubuntu
-    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:20.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:22.04
     pre_build_image: true
     pull: true
 

--- a/tests/integration/molecule/role_install_custom_version/molecule.yml
+++ b/tests/integration/molecule/role_install_custom_version/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
   - name: ubuntu
-    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:22.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:18.04
     pre_build_image: true
     pull: true
 

--- a/tests/integration/molecule/role_install_default_deb/molecule.yml
+++ b/tests/integration/molecule/role_install_default_deb/molecule.yml
@@ -33,3 +33,8 @@ platforms:
     image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:18.04
     pre_build_image: true
     pull: true
+
+  - name: ubuntu-20.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:20.04
+    pre_build_image: true
+    pull: true

--- a/tests/integration/molecule/role_install_default_deb/molecule.yml
+++ b/tests/integration/molecule/role_install_default_deb/molecule.yml
@@ -38,8 +38,3 @@ platforms:
     image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:20.04
     pre_build_image: true
     pull: true
-
-  # - name: ubuntu-22.04
-  #   image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:22.04
-  #   pre_build_image: true
-  #   pull: true

--- a/tests/integration/molecule/role_install_default_deb/molecule.yml
+++ b/tests/integration/molecule/role_install_default_deb/molecule.yml
@@ -38,3 +38,8 @@ platforms:
     image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:20.04
     pre_build_image: true
     pull: true
+
+  - name: ubuntu-22.04
+    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:22.04
+    pre_build_image: true
+    pull: true

--- a/tests/integration/molecule/role_install_default_deb/molecule.yml
+++ b/tests/integration/molecule/role_install_default_deb/molecule.yml
@@ -39,7 +39,7 @@ platforms:
     pre_build_image: true
     pull: true
 
-  - name: ubuntu-22.04
-    image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:22.04
-    pre_build_image: true
-    pull: true
+  # - name: ubuntu-22.04
+  #   image: quay.io/xlab-steampunk/sensu-go-tests-ubuntu:22.04
+  #   pre_build_image: true
+  #   pull: true


### PR DESCRIPTION
- Docker file configurations for Ubuntu 20.04 and 22.04
- Install ansible.posix with ansible-galaxy for integration tests
- pip molecule packages version bump 
- Add archive.debian.org repo to Debian 9 source.list